### PR TITLE
Docker support via Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:14-alpine
+
+ENV WORKDIR=/qboard
+ENV USER=qboard
+ENV GROUP=$USER
+
+WORKDIR $WORKDIR
+
+RUN addgroup -S $GROUP \
+ && adduser -S $USER -G $GROUP -D \
+ && chown $USER:$GROUP $WORKDIR
+USER qboard
+
+COPY ./ .
+ 
+RUN npm install nwb@0.25.2
+RUN npm run build 
+
+ENTRYPOINT ["npm"]
+CMD ["start"]
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -52,24 +52,4 @@ The main source is [qboard.ts](src/lib/qboard.ts), which handles listening to mo
 - [styles.ts](src/lib/styles.ts), which gives an interface for changing pen style.
 - [tools.ts](src/lib/tools.ts), which implements each non-free-drawing tool.
 
-## Running as a container
-
-The `Dockerfile` included can be used to build a container image that will work across different container runtimes, such as Docker. This is based on the official [node:alpine container](https://hub.docker.com/_/node).
-
-Build the container image
-
-```bash
-docker build -t qboard . 
-```
-
-Run the built container image
-
-```bash
-docker run -d --name qboard qboard
-```
-
-Run on an alternative port number (8080)
-
-```bash
-docker run -d --name qboard -p 8080:3000 qboard
-```
+Running `npm start` will start the development server. Run `npm run build` to bundle it. There's also a [Dockerfile](Dockerfile); build the image with `docker build -t qboard .`, then run with `docker run -d --name qboard qboard`. 

--- a/README.md
+++ b/README.md
@@ -51,3 +51,25 @@ The main source is [qboard.ts](src/lib/qboard.ts), which handles listening to mo
 - [keyboard.ts](src/lib/keyboard.ts), which catches keyboard events that aren't H.
 - [styles.ts](src/lib/styles.ts), which gives an interface for changing pen style.
 - [tools.ts](src/lib/tools.ts), which implements each non-free-drawing tool.
+
+## Running as a container
+
+The `Dockerfile` included can be used to build a container image that will work across different container runtimes, such as Docker. This is based on the official [node:alpine container](https://hub.docker.com/_/node).
+
+Build the container image
+
+```bash
+docker build -t qboard . 
+```
+
+Run the built container image
+
+```bash
+docker run -d --name qboard qboard
+```
+
+Run on an alternative port number (8080)
+
+```bash
+docker run -d --name qboard -p 8080:3000 qboard
+```


### PR DESCRIPTION
I have created a Dockerfile to build qboard into a container image. This can be used on different Linux container runtimes. I have also added docker build/run commands to the README. 

I have not pushed this to Docker Hub, as this is potentially something you may want to own for the project. Doing so would let others simply request the container, rather than download and build. However, [Docker is starting to impose limits on Docker Hub](https://www.techradar.com/uk/news/docker-could-be-set-to-delete-all-your-files-if-you-havent-accessed-them-for-a-while) usage wherein less frequently pulled images are deleted unless you are a paying user. 

**Dockerfile Explanation**

- The base image is the Docker official node, using the alpine variant to reduce size, and version tagging this to the v14 line. 
- A user/group is created to run qboard within the container as recommended by [Docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user).
- `nwb` is installed, with a version tag of `0.25.2` rather than default `latest`. Then `qboard` build is ran.
- `npm` is set as the `entrypoint`, with `start` set as the `cmd` as recommended by [Docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint). This allows the `cmd` to be overridden by the user for testing/debugging, having their arguments passed to `npm`.
- The port `3000` is exposed and used by default. The user can override this with docker `-p 8080:3000` mappings.

I have tested this on my local machine, running Fedora 33 and Podman (rather than Docker, Podman has ["Support for a Docker-compatible CLI interface"](https://github.com/containers/podman) and is included by default on Fedora/Centos systems). Commands in the README are docker based, not podman, as it is the common choice. 

Please let me know what you think and if you have any questions. 