### PR TITLE
Deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules
 npm-debug.log*
 deploy.sh
+deploy.js

--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   type: "react-app",
   webpack: {
+    publicPath: "",
     config(config) {
       config.entry = "./src/index.js";
       config.resolve.extensions = [".ts", ".tsx", ".js", ".jsx"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -7966,6 +7966,12 @@
         "side-channel": "^1.0.2"
       }
     },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -12646,6 +12652,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -13523,6 +13538,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "side-channel": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "build": "nwb build-react-app",
     "clean": "nwb clean-app",
+    "predeploy": "npm run build",
+    "deploy": "node deploy.js",
     "start": "nwb serve-react-app"
   },
   "dependencies": {
@@ -32,6 +34,7 @@
     "nwb": "0.25.x",
     "nwb-sass": "^0.10.2",
     "prettier": "^2.1.2",
+    "shelljs": "^0.8.4",
     "stylelint": "^13.7.2",
     "stylelint-config-standard": "^20.0.0",
     "stylelint-scss": "^3.18.0",


### PR DESCRIPTION
Allow deployments.

Use `npm run deploy` to build and then deploy. The deployment runs `deploy.js` in which you can do whatever you want. You can write your deployment script in node or execute your `.sh` script from `deploy.js`. That way, it is very platform-independent.

Adds `deploy.js` to `.gitignore`.