### PR TITLE
Insert at page 0, simplify Pages logic, add documentation

### DIFF
--- a/src/components/BindingModal.tsx
+++ b/src/components/BindingModal.tsx
@@ -8,7 +8,8 @@ import Icon from "./Icon";
 Modal.setAppElement("#Overlay");
 
 const nonBinding: Action[] = [
-  Action.AddPage,
+  Action.AddPageStart,
+  Action.AddPageEnd,
   Action.EnterFullScreen,
   Action.ExitFullScreen,
 ];

--- a/src/components/BindingModal.tsx
+++ b/src/components/BindingModal.tsx
@@ -37,21 +37,20 @@ const BindingModal = (props: {
       >
         <span style={{ left: "0.25em" }}>none</span>
       </button>
-      {Object.values(Action).map(
-        (action) =>
-          !nonBinding.includes(action) && (
-            <button
-              key={action}
-              className={props.action === action ? "active" : undefined}
-              onClick={() => props.callback(action)}
-            >
-              {Icon[action]}
-              <span style={Icon[action] ? {} : { left: "0.25em" }}>
-                {actionName(action)}
-              </span>
-            </button>
-          )
-      )}
+      {Object.values(Action)
+        .filter((action) => !nonBinding.includes(action))
+        .map((action) => (
+          <button
+            key={action}
+            className={props.action === action ? "active" : undefined}
+            onClick={() => props.callback(action)}
+          >
+            {Icon[action]}
+            <span style={Icon[action] ? {} : { left: "0.25em" }}>
+              {actionName(action)}
+            </span>
+          </button>
+        ))}
     </div>
   </Modal>
 );

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -11,7 +11,8 @@ const Icon = {
 
   previousPage: fasIcon("caret-left"),
   nextPage: fasIcon("caret-right"),
-  addPage: fasIcon("plus", { transform: "scale(0.7)" }),
+  addPageStart: fasIcon("plus", { transform: "scale(0.7)" }),
+  addPageEnd: fasIcon("plus", { transform: "scale(0.7)" }),
 
   undo: fasIcon("undo"),
   redo: fasIcon("redo"),

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -32,7 +32,7 @@ const Pagination = (props: {
 
   useEffect(() => void navigate(), [value]);
 
-  const onSubmit: (e) => Promise<void> = (e) => {
+  const onSubmit = (e) => {
     e?.preventDefault();
     return navigate();
   };
@@ -41,11 +41,11 @@ const Pagination = (props: {
 
   return (
     <div className={`pagination visibility-${props.visibility}`}>
-      <OverlayButton
-        className={props.currentPage === 1 ? "disabled" : undefined}
-        action={Action.PreviousPage}
-        callback={props.doAction}
-      />
+      {props.currentPage === 1 ? (
+        <OverlayButton action={Action.AddPageStart} callback={props.doAction} />
+      ) : (
+        <OverlayButton action={Action.PreviousPage} callback={props.doAction} />
+      )}
       <form onSubmit={onSubmit}>
         <input
           onChange={onChange}
@@ -57,7 +57,7 @@ const Pagination = (props: {
       </form>
       <span className="total-pages"> / {props.totalPages}</span>
       {props.currentPage === props.totalPages ? (
-        <OverlayButton action={Action.AddPage} callback={props.doAction} />
+        <OverlayButton action={Action.AddPageEnd} callback={props.doAction} />
       ) : (
         <OverlayButton action={Action.NextPage} callback={props.doAction} />
       )}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -41,11 +41,12 @@ const Pagination = (props: {
 
   return (
     <div className={`pagination visibility-${props.visibility}`}>
-      {props.currentPage === 1 ? (
-        <OverlayButton action={Action.AddPageStart} callback={props.doAction} />
-      ) : (
-        <OverlayButton action={Action.PreviousPage} callback={props.doAction} />
-      )}
+      <OverlayButton
+        action={
+          props.currentPage === 1 ? Action.AddPageStart : Action.PreviousPage
+        }
+        callback={props.doAction}
+      />
       <form onSubmit={onSubmit}>
         <input
           onChange={onChange}
@@ -56,11 +57,14 @@ const Pagination = (props: {
         />
       </form>
       <span className="total-pages"> / {props.totalPages}</span>
-      {props.currentPage === props.totalPages ? (
-        <OverlayButton action={Action.AddPageEnd} callback={props.doAction} />
-      ) : (
-        <OverlayButton action={Action.NextPage} callback={props.doAction} />
-      )}
+      <OverlayButton
+        action={
+          props.currentPage === props.totalPages
+            ? Action.AddPageEnd
+            : Action.NextPage
+        }
+        callback={props.doAction}
+      />
     </div>
   );
 };

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -11,7 +11,8 @@ import React from "react";
 export enum Action {
   PreviousPage = "previousPage",
   NextPage = "nextPage",
-  AddPage = "addPage",
+  AddPageStart = "addPageStart",
+  AddPageEnd = "addPageEnd",
 
   Undo = "undo",
   Redo = "redo",
@@ -58,7 +59,8 @@ export enum Action {
 const nameMap = {
   previousPage: "–Page",
   nextPage: "+Page",
-  addPage: "+Page",
+  addPageStart: "-Page",
+  addPageEnd: "+Page",
   selectAll: "Select All",
   duplicate: "Clone",
   eraser: "Cut / Eraser",
@@ -108,9 +110,10 @@ export default class ActionHandler {
     this.canvas = this.pages.canvas;
 
     this.actionMap = {
-      previousPage: pages.previousPage,
+      previousPage: pages.previousOrNewPage,
       nextPage: pages.nextOrNewPage,
-      addPage: pages.nextOrNewPage,
+      addPageStart: pages.previousOrNewPage,
+      addPageEnd: pages.nextOrNewPage,
 
       undo: history.undo,
       redo: history.redo,

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -181,6 +181,6 @@ export default class FileHandler {
 
   private handleJSON = async (file: File): Promise<number> => {
     const pages = JSONReader.read(await AsyncReader.readAsText(file));
-    return this.pages.insertPages(this.pages.currentIndex + 1, pages);
+    return this.pages.insertPagesAfter(pages);
   };
 }

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -71,7 +71,7 @@ export default class Pages {
    */
   previousOrNewPage = (): Promise<number> => {
     if (this.currentIndex === 0) {
-      return this.insertPagesBefore([defaultPageJSON]);
+      return this.insertPagesBefore([defaultPageJSON], true);
     }
     return this.loadPage(this.currentIndex - 1);
   };
@@ -82,7 +82,7 @@ export default class Pages {
    */
   nextOrNewPage = (): Promise<number> => {
     if (this.currentIndex === this.pagesJSON.length - 1) {
-      return this.insertPagesAfter([defaultPageJSON]);
+      return this.insertPagesAfter([defaultPageJSON], true);
     }
     return this.loadPage(this.currentIndex + 1);
   };

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -42,6 +42,14 @@ export default class Pages {
     ]);
   };
 
+  /**
+   * Safe method to load a specific page in UI
+   * @param index The 0-based index of the page to load
+   * @param saveExisting
+   * Whether to save the contents on the current page to memory.
+   * Forces an unconditional re-render when set to false.
+   * May need to set to false if directly manipulating the internal array.
+   */
   // TODO: Should saveExisting be renamed and negated to force?
   loadPage = async (index: number, saveExisting = true): Promise<number> => {
     if (saveExisting) this.savePage();

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -44,8 +44,8 @@ export default class Pages {
 
   // TODO: Should saveExisting be renamed and negated to force?
   loadPage = async (index: number, saveExisting = true): Promise<number> => {
-    if (index === this.currentIndex && saveExisting) return index;
     if (saveExisting) this.savePage();
+    if (index === this.currentIndex && saveExisting) return index;
     await this.canvas.loadFromJSONAsync(this.pagesJSON[index]);
     this.currentIndex = index;
     this.updateState();

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -51,7 +51,7 @@ export default class Pages {
     if (saveExisting) this.savePage();
     await this.canvas.loadFromJSONAsync(this.pagesJSON[index]);
     this.currentIndex = index;
-    if (saveExisting || force) this.updateState();
+    this.updateState();
     return index;
   };
 

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -42,12 +42,9 @@ export default class Pages {
     ]);
   };
 
-  loadPage = async (
-    index: number,
-    saveExisting = true,
-    force = false
-  ): Promise<number> => {
-    if (index === this.currentIndex && !force) return index;
+  // TODO: Should saveExisting be renamed and negated to force?
+  loadPage = async (index: number, saveExisting = true): Promise<number> => {
+    if (index === this.currentIndex && saveExisting) return index;
     if (saveExisting) this.savePage();
     await this.canvas.loadFromJSONAsync(this.pagesJSON[index]);
     this.currentIndex = index;
@@ -117,7 +114,7 @@ export default class Pages {
     if (!response) return false;
 
     this.pagesJSON = pages;
-    await this.loadPage(0, false, true);
+    await this.loadPage(0, false);
     this.canvas.modified = false;
     return true;
   };
@@ -133,7 +130,7 @@ export default class Pages {
     if (!isNonModifying) {
       this.canvas.modified = true;
     }
-    return this.loadPage(this.currentIndex, false, true);
+    return this.loadPage(this.currentIndex, false);
   };
 
   insertPagesAfter = async (

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -46,13 +46,17 @@ export default class Pages {
   };
 
   /**
-   * Safe method to load "move to"/"switch to" a specific page in UI
+   * Safe method to load "move to"/"switch to" a specific page in UI.
+   * Will not do anything if `{@param index} === this.currentIndex && {@param saveExisting}`.
+   *
    * @param index The 0-based index of the page to load
    * @param saveExisting
    * Whether to save the contents on the current page to memory before switching pages.
-   * Forces an unconditional re-render when set to `false`.
-   * May need to set to `false` if directly manipulating the internal array.
-   * @return The index of the loaded page.
+   * Forces an unconditional re-render when set to `false`,
+   * as opposed to not doing anything if the current page is {@param index}.
+   * May need to set to `false` if directly manipulating the internal array to prevent an override.
+   * @return
+   * The index of the loaded page.
    * This equals {@param index}.
    */
   // TODO: Should saveExisting be renamed and negated to force?

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -131,6 +131,7 @@ export default class Pages {
     pages: PageJSON[],
     isNonModifying = false
   ): Promise<number> => {
+    this.savePage();
     this.pagesJSON.splice(this.currentIndex, 0, ...pages);
     // make sure not to do
     // this.canvas.modified = !isNonModifying

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -44,29 +44,29 @@ export default class Pages {
 
   loadPage = async (
     index: number,
-    dontSaveExisting = false,
+    saveExisting = true,
     force = false
   ): Promise<number> => {
     if (index === this.currentIndex && !force) return index;
-    if (!dontSaveExisting) this.savePage();
+    if (saveExisting) this.savePage();
     await this.canvas.loadFromJSONAsync(this.pagesJSON[index]);
     this.currentIndex = index;
-    if (!dontSaveExisting || force) this.updateState();
+    if (saveExisting || force) this.updateState();
     return index;
   };
 
-  previousOrNewPage = async (fromFile: boolean = false): Promise<number> => {
+  previousOrNewPage = async (): Promise<number> => {
     if (this.currentIndex === 0) {
       return this.insertPagesBefore([defaultPageJSON]);
     }
-    return this.loadPage(this.currentIndex - 1, fromFile);
+    return this.loadPage(this.currentIndex - 1);
   };
 
-  nextOrNewPage = async (fromFile: boolean = false): Promise<number> => {
+  nextOrNewPage = async (): Promise<number> => {
     if (this.currentIndex === this.pagesJSON.length - 1) {
       return this.insertPagesAfter([defaultPageJSON]);
     }
-    return this.loadPage(this.currentIndex + 1, fromFile);
+    return this.loadPage(this.currentIndex + 1);
   };
 
   export = async (): Promise<void> => {
@@ -117,7 +117,7 @@ export default class Pages {
     if (!response) return false;
 
     this.pagesJSON = pages;
-    await this.loadPage(0, true, true);
+    await this.loadPage(0, false, true);
     this.canvas.modified = false;
     return true;
   };
@@ -133,7 +133,7 @@ export default class Pages {
     if (!isNonModifying) {
       this.canvas.modified = true;
     }
-    return this.loadPage(this.currentIndex, true);
+    return this.loadPage(this.currentIndex, false, true);
   };
 
   insertPagesAfter = async (
@@ -147,6 +147,6 @@ export default class Pages {
     if (!isNonModifying) {
       this.canvas.modified = true;
     }
-    return this.loadPage(this.currentIndex + 1, false);
+    return this.loadPage(this.currentIndex + 1, true);
   };
 }


### PR DESCRIPTION
Resolves https://github.com/cjquines/qboard/issues/92

The logical step is 9964624. Uses plus sign as icon, ~~which is a bit weird on a clean board when there are plusses in both directions, but this is likely because I'm used to the existing way~~.

I removed the `force` option in `loadPage` because it wasn't being used and YAGNI but it should probably be discussed (see line 62 below, 225d87c, and ee63dd9):
https://github.com/cjquines/qboard/blob/eed288d37e61d50a6f9ea9794850ac1662e72a0a/src/lib/pages.ts#L48-L70

The method `insertPages(index: number, pages)` was replaced with the weaker `insertPagesAfter(pages)`, which inserts pages after the `currentIndex`, not an arbitrary `index`. The function in full generality was never going to be used and it had a greater logical burden when determining which flags to set and what the execution order should be. To handle the insertion at 0 case, I added `insertPagesBefore(pages)` which is very similar. Splitting it up largely reduces the possibility of off-by-one errors, makes the call site easier to reason about, and expresses intent more clearly. These two functions _can_ be combined, but then a (smaller, but still significant) logical burden arises.

I did not remove any existing CSS for `button.disabled` but I can do that if desired

---

sorry, i had this ready earlier but forgot to push