### PR TITLE
Fix open action

### DIFF
--- a/src/components/ButtonRow.tsx
+++ b/src/components/ButtonRow.tsx
@@ -6,7 +6,7 @@ import OverlayButton from "./OverlayButton";
 
 const ButtonRow = (props: {
   actions: Action[];
-  callback: (action: Action) => Promise<void>;
+  callback: (action: Action) => void;
   className?: (action: Action, i: number) => undefined | string;
   cName?: string;
   outerButton?: boolean | ReactNode;

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -7,7 +7,7 @@ import StyleMenu from "./StyleMenu";
 
 const ContextMenu = (props: {
   currentStyle: Style;
-  doAction: (action: Action) => Promise<void>;
+  doAction: (action: Action) => void;
 }): JSX.Element | null => {
   const [coords, setCoords] = useState<[number, number] | null>(null);
 

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -11,6 +11,7 @@ import Toolbar from "./Toolbar";
 import Stylebar from "./Stylebar";
 import HelpModal from "./HelpModal";
 import ContextMenu from "./ContextMenu";
+import VirtualFileInput from "./VirtualFileInput";
 
 export const enum Visibility {
   None,
@@ -75,6 +76,14 @@ const Overlay = ({ qboard }: { qboard: QBoard }): JSX.Element => {
 
   return (
     <>
+      <VirtualFileInput
+        acceptFiles={qboard.files.acceptFile}
+        captureRef={(ref) => {
+          qboard.globalState.fileInputRef = ref;
+        }}
+        multiple
+        accept="application/json, application/pdf, image/*"
+      />
       <div className={`drop-area ${state.dragActive ? "active" : ""}`} />
       <div className={`overlay visibility-${visibility}`}>
         <Pagination

--- a/src/components/OverlayButton.tsx
+++ b/src/components/OverlayButton.tsx
@@ -7,7 +7,7 @@ import Icon from "./Icon";
 
 const OverlayButton = (props: {
   action: Action;
-  callback: (action: Action) => Promise<void>;
+  callback: (action: Action) => void;
   className?: string;
 }): JSX.Element => {
   return (

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -9,7 +9,7 @@ const Pagination = (props: {
   loadPage: (index: number) => Promise<void | number>;
   currentPage: number;
   totalPages: number;
-  doAction: (action: Action) => Promise<void>;
+  doAction: (action: Action) => void;
   visibility: Visibility;
 }): JSX.Element => {
   const [value, setValue] = useState(0);

--- a/src/components/StyleMenu.tsx
+++ b/src/components/StyleMenu.tsx
@@ -7,7 +7,7 @@ import Icon from "./Icon";
 import ButtonRow from "./ButtonRow";
 
 type StyleOptions = {
-  callback: (action: Action) => Promise<void>;
+  callback: (action: Action) => void;
   inContext?: boolean;
 };
 
@@ -96,7 +96,7 @@ const FillStyle = ({
 
 const StyleMenu = (props: {
   currentStyle: Style;
-  doAction: (action: Action) => Promise<void>;
+  doAction: (action: Action) => void;
   inContext?: boolean;
 }): JSX.Element => {
   return (

--- a/src/components/Stylebar.tsx
+++ b/src/components/Stylebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { Style } from "../lib/styles";
 import { Action } from "../lib/action";
@@ -15,7 +15,6 @@ const Stylebar = (props: {
   visibility: Visibility;
   isMobile: boolean;
 }): JSX.Element => {
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const fileButton = <button className="inactive">{Icon.file}</button>;
   const fileActions = [Action.Open, Action.Save, Action.Export];
 
@@ -33,22 +32,9 @@ const Stylebar = (props: {
 
   return (
     <div className={`stylebar visibility-${props.visibility}`}>
-      <input
-        accept=""
-        onChange={(e) => props.acceptFile(e.target.files!)}
-        multiple={false}
-        ref={fileInputRef}
-        type="file"
-      />
       <ButtonRow
         actions={fileActions}
-        callback={async (action) => {
-          if (action === Action.Open) {
-            fileInputRef.current?.click();
-          } else {
-            await props.doAction(action);
-          }
-        }}
+        callback={props.doAction}
         cName="file-actions"
         outerButton={fileButton}
       />

--- a/src/components/Stylebar.tsx
+++ b/src/components/Stylebar.tsx
@@ -10,7 +10,7 @@ import StyleMenu from "./StyleMenu";
 
 const Stylebar = (props: {
   currentStyle: Style;
-  doAction: (action: Action) => Promise<void>;
+  doAction: (action: Action) => void;
   acceptFile: (files: FileList) => Promise<void | void[]>;
   visibility: Visibility;
   isMobile: boolean;

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -9,7 +9,7 @@ import OverlayButton from "./OverlayButton";
 const Toolbar = (props: {
   currentTool: Tool;
   tools: Tools;
-  doAction: (action: Action) => Promise<void>;
+  doAction: (action: Action) => void;
   visibility: Visibility;
 }): JSX.Element => {
   const items = [

--- a/src/components/UndoRedo.tsx
+++ b/src/components/UndoRedo.tsx
@@ -8,7 +8,7 @@ import OverlayButton from "./OverlayButton";
 const UndoRedo = (props: {
   canUndo: boolean;
   canRedo: boolean;
-  doAction: (action: Action) => Promise<void>;
+  doAction: (action: Action) => void;
   visibility: Visibility;
 }): JSX.Element => {
   return (

--- a/src/components/VirtualFileInput.tsx
+++ b/src/components/VirtualFileInput.tsx
@@ -1,0 +1,54 @@
+import React, { useRef } from "react";
+
+/**
+ * Passed to [[`OverlayButton`]]
+ */
+interface OverlayButtonProps {
+  /**
+   * An `onChange` callback that is given the extracted `FileList` as {@param files} if and only if
+   * * it exists (is non-null), and
+   * * has at least one file.
+   * Otherwise, it is not called.
+   *
+   * Use the `onChange` attribute if you instead want the raw handler
+   */
+  acceptFiles?: (files: FileList) => void;
+
+  /**
+   * Your own callback so that you can record the reference {@param ref} to the input.
+   * That way, you can invoke `click()`, and therefore open the file dialog, programmatically.
+   */
+  captureRef?: (ref: React.RefObject<HTMLInputElement>) => void;
+}
+
+const OverlayButton = ({
+  acceptFiles,
+  captureRef,
+  ...attrs
+}: OverlayButtonProps &
+  React.DetailedHTMLProps<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  >): JSX.Element => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  captureRef?.(fileInputRef);
+
+  return (
+    <input
+      onChange={
+        acceptFiles === undefined
+          ? undefined
+          : (e) => {
+              if (e.target.files?.length) acceptFiles(e.target.files);
+            }
+      }
+      ref={fileInputRef}
+      type="file"
+      style={{ display: "none" }}
+      {...attrs}
+    />
+  );
+};
+
+export default OverlayButton;

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -76,12 +76,9 @@ export const actionName = (action: Action): string => {
   return name && name[0].toUpperCase() + name.slice(1);
 };
 
-type Async<T = void> = T | Promise<T>;
-
 export default class ActionHandler {
   canvas: fabric.Canvas;
-  // FIXME: async to keep commit clean; don't need to change signatures
-  readonly actionMap: Record<Action, () => Async<unknown>>;
+  readonly actionMap: Record<Action, () => void>;
 
   constructor(
     public switchTool: (tool: Tool) => void,
@@ -178,9 +175,7 @@ export default class ActionHandler {
     };
   }
 
-  doAction = async (action: Action): Promise<void> => {
-    await this.actionMap[action]();
-  };
+  doAction = (action: Action): void => this.actionMap[action]();
 
   setDash = (dash: Dash): void => {
     if (dash === this.currentStyle.dash) {

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -76,7 +76,7 @@ export default class KeyboardHandler {
   keyMap: KeyMap = {};
 
   constructor(
-    public doAction: (action: Action) => Promise<void>,
+    public doAction: (action: Action) => void,
     public setStrict: (strict: boolean) => void,
     public updateState: () => void
   ) {

--- a/src/lib/qboard.ts
+++ b/src/lib/qboard.ts
@@ -66,6 +66,16 @@ export default class QBoard {
   strict = false;
   callback: ((state: QBoardState) => void) | undefined;
 
+  /**
+   * Intentionally mutable global state object
+   */
+  public globalState: {
+    /**
+     * A ref to the global input element used for file input
+     */
+    fileInputRef?: React.RefObject<HTMLInputElement>;
+  } = {};
+
   constructor(
     public canvasElement: HTMLCanvasElement & HTMLChildElement,
     public baseCanvasElement: HTMLCanvasElement & HTMLChildElement,
@@ -121,7 +131,8 @@ export default class QBoard {
       this.files,
       this.history,
       this.clipboard,
-      this.style.set
+      this.style.set,
+      this.globalState
     );
     this.keyboard = new KeyboardHandler(
       this.action.doAction,


### PR DESCRIPTION
There was an ugly hack that erroneously put `files.acceptFile` as the handler for the `open` action. This resulted in duplicated code and an explicit check to override the action behavior for only the `open` action. Of course, this didn't even work as an action: the handler requires a `FileList` as an argument, which is not a thing that exists for action handlers (hence the horrible hack of a type definition).

The reason for this hack was to get the reference to the file input element, so that its `click()` property could get invoked programmatically (on click of the UI button). Fixing this particular use case is easy (with another hack): just use the UI button element as a label for the input. However, that's short-sighted, as it completely ignores any use for open as an actual action. It's also obviously not scalable, itself requiring hard-coded hacks and a specific component structure.

This PR introduces a somewhat less hacky—and far more type safe—way to pass the input element reference: whenever the `Ref` is created, send it to a callback. This callback will add it to a global state object so it can be retrieved by any other code in the project, namely the open action handler and `action.ts` overall.
> The `VirtualFileInput` component has no clue what the ref is being used for; it just gives it to the callback if one is provided. It's parent component, `Overlay`, on the other hand, _does_ know what it's being used for; the component itself updates the global state, instead of passing it up another level for `QBoard` to process. I figured it would be easier to do it this way since overlay already has access to the entire `QBoard` instance, and functions as a main `App.tsx` component would in other projects. However, if this is used for more complex situations, it may make sense to make `QBoard`'s `globalState` private, and instead pass the global state object to any component requesting it _OR_ make it private and send the ref up to a callback in either props or `props.qboard`. This is a very easy refactor that imo should be postponed until the complicated use case shows up.

This now makes all actions synchronous, as I believe they should have always been, so we improve the logic and type safety of that too (type safety as in if you await a non-promise object that happens to have a `then` property, you have broken your logic; it will not just return the object unchanged as you would expect it to).

One thing I can do is extract the entire global state into its own file/interface/class/whatever. This would work fine, and potentially remove semi-duplicated comments, but keeping them separate, you can add more type safety by marking certain properties as readonly in the call site. Of course, *none* of the properties in the actual global state object can be readonly (that's the whole point, although you could force constants into there if you didn't like separate config objects), so the only way to provide this type safety is by repeating the declaration of the properties in the interface that are used.