### PR TITLE
Temporarily un-expose mobile mode from the UI

### DIFF
--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -17,7 +17,7 @@ const HelpModal = (props: {
   isOpen: boolean;
   toggleOpen: () => void;
   isMobile: boolean;
-  toggleMobility: () => void;
+  // toggleMobility: () => void;
 }): JSX.Element => {
   const [keyModifier, setKeyModifier] = useState("");
   const [leftHanded, setLeftHanded] = useState(false);
@@ -94,11 +94,11 @@ const HelpModal = (props: {
       <p style={{ color: "#666" }}>
         By <a href="https://cjquines.com/">CJ Quines</a> and{" "}
         <a href="https://pihart.github.io/">Avi Mehra</a>. View on{" "}
-        <a href="https://github.com/cjquines/qboard">Github</a>. Use{" "}
+        <a href="https://github.com/cjquines/qboard">Github</a>.
+        {/* Use{" "}
         <a onClick={() => props.toggleMobility()} tabIndex={0}>
           {props.isMobile ? "desktop" : "mobile"} site
-        </a>
-        .
+        </a>.*/}
       </p>
     </Modal>
   );

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -22,7 +22,8 @@ export const enum Visibility {
 const Overlay = ({ qboard }: { qboard: QBoard }): JSX.Element => {
   const [visibility, setVisibility] = useState<Visibility>(Visibility.Full);
   const [helpModalOpen, setHelpModalOpen] = useState(false);
-  const [isMobile, setMobility] = useState(false);
+  // const [isMobile, setMobility] = useState(false);
+  const isMobile = true;
 
   const [state, setState]: [
     QBoardState,
@@ -48,20 +49,22 @@ const Overlay = ({ qboard }: { qboard: QBoard }): JSX.Element => {
     });
   };
 
-  const toggleMobility = (): void => {
+  // Code is temporarily dead as a result of https://github.com/cjquines/qboard/issues/91;
+  // Commenting so it can get erased in build
+  /*const toggleMobility = (): void => {
     setMobility((wasMobile) => {
       window.localStorage.setItem("isMobile", wasMobile ? "false" : "true");
       return !wasMobile;
     });
-  };
+  };*/
 
   useEffect(() => {
     if (window.localStorage.getItem("helpModalOpen") !== "false") {
       setHelpModalOpen(true);
     }
-    if (window.localStorage.getItem("isMobile") !== "false") {
-      setMobility(true);
-    }
+    // if (window.localStorage.getItem("isMobile") !== "false") {
+    //   setMobility(true);
+    // }
 
     qboard.callback = setState;
     qboard.updateState();
@@ -124,7 +127,7 @@ const Overlay = ({ qboard }: { qboard: QBoard }): JSX.Element => {
           isOpen={helpModalOpen}
           toggleOpen={toggleOpen}
           isMobile={isMobile}
-          toggleMobility={toggleMobility}
+          // toggleMobility={toggleMobility}
         />
       </div>
       <ContextMenu


### PR DESCRIPTION
In code, assume everyone has mobile mode.

Resolves https://github.com/cjquines/qboard/issues/91. See issue for more details.

Revert this commit before doing anything to either mode.