### PR TITLE
Add basic developer mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,11 @@ import QBoard from "./lib/qboard";
 
 import "./main.scss";
 
-const qboard = new QBoard(
+// The live [[`QBoard`]] instance, exposed to the public as a basic developer interface.
+// Technically, the developer-user gets less control over private fields,
+// but from a power user standpoint this is likely not an issue;
+// no user should be writing scripts that depend on private fields.
+window.qboard = new QBoard(
   document.querySelector("#QBoard"),
   document.querySelector("#BaseQBoard"),
   1600,
@@ -14,6 +18,6 @@ const qboard = new QBoard(
 );
 
 ReactDOM.render(
-  <Overlay qboard={qboard} />,
+  <Overlay qboard={window.qboard} />,
   document.querySelector("#Overlay")
 );


### PR DESCRIPTION
Expose the QBoard instance to the public by attaching it to `window` as `window.qboard`.

Resolves https://github.com/cjquines/qboard/issues/89

(Sort of a misnomer—this is always enabled, not a mode. In the future, a true developer mode could expose internals directly in the UI.)