### PR TITLE
Allow binding to full keyboard

### DIFF
--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -49,8 +49,8 @@ const Bindings = (props: {
     [
       { type: "modifier", key: "shift", value: "Snap", width: "7.5em" },
       ...Keys(["z", "x", "c", "v", "b", "n", "m", "/"]),
-      { type: "modifier", key: "ctrl", width: "3.5em" },
-      { type: "modifier", key: "alt", width: "3.5em" },
+      { type: "modifier", key: "ctrl" },
+      { type: "modifier", key: "alt" },
     ],
   ];
 

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -15,13 +15,8 @@ const Bindings = (props: {
   unbind: (key: string) => void;
   keyMap: KeyMap;
 }): JSX.Element => {
-  const [bindingModalKeys, setBindingModalKeys]: [
-    string,
-    React.Dispatch<React.SetStateAction<string>>
-  ] = useState<string>("");
-  const [bindingModalAction, setBindingModalAction] = useState<Action | null>(
-    null
-  );
+  const [keys, setKeys] = useState<string>("");
+  const [action, setAction] = useState<Action | null>(null);
   const [modifiers, setModifiers] = useState(new Set<string>());
 
   const modify = (key: string) =>
@@ -60,8 +55,8 @@ const Bindings = (props: {
 
   const keyHandler = (key: string): void => {
     const modified = modify(key);
-    setBindingModalKeys(modified);
-    setBindingModalAction(props.keyMap[modified]);
+    setKeys(modified);
+    setAction(props.keyMap[modified]);
   };
 
   return (
@@ -74,13 +69,13 @@ const Bindings = (props: {
         setActiveModifiers={setModifiers}
       />
       <BindingModal
-        letter={bindingModalKeys}
-        action={bindingModalAction}
-        close={() => setBindingModalKeys("")}
+        letter={keys}
+        action={action}
+        close={() => setKeys("")}
         callback={(action) => {
-          props.unbind(bindingModalKeys);
-          if (action) props.bind(bindingModalKeys, action);
-          setBindingModalKeys("");
+          props.unbind(keys);
+          if (action) props.bind(keys, action);
+          setKeys("");
         }}
       />
     </>

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -15,8 +15,8 @@ const Bindings = (props: {
   unbind: (key: string) => void;
   keyMap: KeyMap;
 }): JSX.Element => {
-  const [keys, setKeys] = useState<string>("");
-  const [action, setAction] = useState<Action | null>(null);
+  const [bindingHotkey, setBindingHotkey] = useState<string>("");
+  const [hotkeyAction, setHotkeyAction] = useState<Action | null>(null);
   const [modifiers, setModifiers] = useState(new Set<string>());
 
   const modify = (key: string) =>
@@ -56,8 +56,8 @@ const Bindings = (props: {
 
   const keyHandler = (key: string): void => {
     const modified = modify(key);
-    setKeys(modified);
-    setAction(props.keyMap[modified]);
+    setBindingHotkey(modified);
+    setHotkeyAction(props.keyMap[modified]);
   };
 
   return (
@@ -70,13 +70,13 @@ const Bindings = (props: {
         setActiveModifiers={setModifiers}
       />
       <BindingModal
-        letter={keys}
-        action={action}
-        close={() => setKeys("")}
+        letter={bindingHotkey}
+        action={hotkeyAction}
+        close={() => setBindingHotkey("")}
         callback={(action) => {
-          props.unbind(keys);
-          if (action) props.bind(keys, action);
-          setKeys("");
+          props.unbind(bindingHotkey);
+          if (action) props.bind(bindingHotkey, action);
+          setBindingHotkey("");
         }}
       />
     </>

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -23,36 +23,30 @@ const Bindings = (props: {
     null
   );
 
+  const Keys = (keys: string[]) =>
+    keys.map((key) => ({
+      key,
+      action: props.keyMap[key],
+    }));
+
   const rows: Readonly<
     NonEmptyArray<Readonly<NonEmptyArray<UIKeyDescriptor>>>
   > = [
     [
       { key: "`", action: props.keyMap["`"] }, // this is on its own line so I don't need to fight with typescript for it to know that the array is NonEmptyArray
-      ...["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"].map((key) => ({
-        key,
-        action: props.keyMap[key],
-      })),
+      ...Keys(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]),
     ],
     [
       { type: "readonly", key: "tab", value: "Hide Toolbar", width: "4.5em" },
-      ...["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"].map((key) => ({
-        key,
-        action: props.keyMap[key],
-      })),
+      ...Keys(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"]),
     ],
     [
       { type: "readonly", key: "esc", value: "Deselect", width: "6em" },
-      ...["a", "s", "d", "f", "g", "h", "j", "k", "l"].map((key) => ({
-        key,
-        action: props.keyMap[key],
-      })),
+      ...Keys(["a", "s", "d", "f", "g", "h", "j", "k", "l"]),
     ],
     [
       { type: "modifier", key: "shift", value: "Snap", width: "7.5em" },
-      ...["z", "x", "c", "v", "b", "n", "m", "?"].map((key) => ({
-        key,
-        action: props.keyMap[key],
-      })),
+      ...Keys(["z", "x", "c", "v", "b", "n", "m", "?"]),
       { type: "modifier", key: "ctrl", width: "6em" },
     ],
   ];

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -6,6 +6,8 @@ import { KeyMap } from "../lib/keyboard";
 
 import { Key, UnbindableKey } from "./Keyboard";
 import BindingModal from "./BindingModal";
+import { Keyboard, UIKeyDescriptor } from "./Keyboard";
+import { NonEmptyArray } from "@mehra/ts";
 
 Modal.setAppElement("#Overlay");
 
@@ -64,32 +66,24 @@ const Bindings = (props: {
     ],
   ];
 
-  const getModified = (letter: string): string =>
-    props.modifier === "" ? letter : `${props.modifier} + ${letter}`;
-
-  const keyHandler = (letter: string): void => {
-    setBindingModalKeys(getModified(letter));
-    setBindingModalAction(props.keyMap[getModified(letter)]);
+  const keyHandler = ({
+    key,
+    modifiers,
+  }: {
+    key: string;
+    modifiers: Set<string>;
+  }): void => {
+    const modified = [
+      ...Array.from(modifiers).sort(), // these are such small arrays that performance doesn't really matter
+      key,
+    ].join(" + ");
+    setBindingModalKeys(modified);
+    setBindingModalAction(props.keyMap[modified]);
   };
 
   return (
     <>
-      <div className="bindings">
-        {rows.map(({ header, letters }, index) => (
-          <div className={`row ${props.leftHanded ? "left" : ""}`} key={index}>
-            {!props.leftHanded && header}
-            {(props.leftHanded ? letters.reverse() : letters).map((letter) => (
-              <Key
-                key={letter}
-                letter={letter}
-                action={props.keyMap[getModified(letter)]}
-                onclick={keyHandler}
-              />
-            ))}
-            {props.leftHanded && header}
-          </div>
-        ))}
-      </div>
+      <Keyboard rows={rows_new} className={"bindings"} onclick={keyHandler} />
       <BindingModal
         letter={bindingModalKeys}
         action={bindingModalAction}

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -38,10 +38,15 @@ const UnbindableKey = ({
 const Key = (props: {
   letter: string;
   action?: Action;
-  callback: (key: string) => void;
+  onclick: (key: string, event: React.MouseEvent<HTMLButtonElement>) => void;
+  width?: string;
 }) => {
   return (
-    <button className="key" onClick={() => props.callback(props.letter)}>
+    <button
+      className="key"
+      onClick={(event) => props.onclick(props.letter, event)}
+      style={{ width: props.width }}
+    >
       <div className="action">
         {props.action && Icon[props.action]}
         <span className={props.action === undefined ? "unassigned" : undefined}>
@@ -102,7 +107,7 @@ const Bindings = (props: {
                 key={letter}
                 letter={letter}
                 action={props.keyMap[getModified(letter)]}
-                callback={keyHandler}
+                onclick={keyHandler}
               />
             ))}
             {props.leftHanded && header}

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -14,7 +14,6 @@ const Bindings = (props: {
   bind: (key: string, action: Action) => void;
   unbind: (key: string) => void;
   keyMap: KeyMap;
-  modifier: string;
   leftHanded: boolean;
 }): JSX.Element => {
   const [bindingModalKeys, setBindingModalKeys]: [

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -22,11 +22,18 @@ const Bindings = (props: {
   const [bindingModalAction, setBindingModalAction] = useState<Action | null>(
     null
   );
+  const [modifiers, setModifiers] = useState(new Set<string>());
+
+  const modify = (key: string) =>
+    [
+      ...Array.from(modifiers).sort(), // these are such small arrays that performance doesn't really matter
+      key,
+    ].join(" + ");
 
   const Keys = (keys: string[]) =>
     keys.map((key) => ({
       key,
-      action: props.keyMap[key],
+      action: props.keyMap[modify(key)],
     }));
 
   const rows: Readonly<
@@ -51,24 +58,21 @@ const Bindings = (props: {
     ],
   ];
 
-  const keyHandler = ({
-    key,
-    modifiers,
-  }: {
-    key: string;
-    modifiers: Set<string>;
-  }): void => {
-    const modified = [
-      ...Array.from(modifiers).sort(), // these are such small arrays that performance doesn't really matter
-      key,
-    ].join(" + ");
+  const keyHandler = (key: string): void => {
+    const modified = modify(key);
     setBindingModalKeys(modified);
     setBindingModalAction(props.keyMap[modified]);
   };
 
   return (
     <>
-      <Keyboard rows={rows} className={"bindings"} onclick={keyHandler} />
+      <Keyboard
+        rows={rows}
+        className={"bindings"}
+        onclick={keyHandler}
+        activeModifiers={modifiers}
+        setActiveModifiers={setModifiers}
+      />
       <BindingModal
         letter={bindingModalKeys}
         action={bindingModalAction}

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -38,6 +38,31 @@ const Bindings = (props: {
       letters: "zxcvb".split(""),
     },
   ];
+  const rows_new: Readonly<
+    NonEmptyArray<Readonly<NonEmptyArray<UIKeyDescriptor>>>
+  > = [
+    [
+      { type: "readonly", key: "tab", value: "Hide Toolbar", width: "4.5em" },
+      ...["q", "w", "e", "r", "t"].map((key) => ({
+        key,
+        action: props.keyMap[key],
+      })),
+    ],
+    [
+      { type: "readonly", key: "esc", value: "Deselect", width: "6em" },
+      ...["a", "s", "d", "f", "g"].map((key) => ({
+        key,
+        action: props.keyMap[key],
+      })),
+    ],
+    [
+      { type: "modifier", key: "shift", value: "Snap", width: "7.5em" },
+      ...["z", "x", "c", "v", "b"].map((key) => ({
+        key,
+        action: props.keyMap[key],
+      })),
+    ],
+  ];
 
   const getModified = (letter: string): string =>
     props.modifier === "" ? letter : `${props.modifier} + ${letter}`;

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -9,7 +9,14 @@ import BindingModal from "./BindingModal";
 
 Modal.setAppElement("#Overlay");
 
-const HeaderKey = (props: {
+/**
+ * For keys whose bounding behavior cannot be changed;
+ * these keys are already mapped to certain app events,
+ * so the key diagram in the UI should not be a button.
+ *
+ * Use if it is meaningful to indicate the app behavior of this key.
+ */
+const UnbindableKey = (props: {
   letter: string;
   label?: string;
   width: string;
@@ -66,7 +73,7 @@ const Bindings = (props: {
   const rows = [
     {
       header: (
-        <HeaderKey
+        <UnbindableKey
           letter="tab"
           label="Hide Toolbar"
           width="4.5em"
@@ -77,7 +84,7 @@ const Bindings = (props: {
     },
     {
       header: (
-        <HeaderKey
+        <UnbindableKey
           letter="esc"
           label="Deselect"
           width="6em"
@@ -88,7 +95,7 @@ const Bindings = (props: {
     },
     {
       header: (
-        <HeaderKey
+        <UnbindableKey
           letter="shift"
           label="Snap"
           width="7.5em"

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -14,7 +14,6 @@ const Bindings = (props: {
   bind: (key: string, action: Action) => void;
   unbind: (key: string) => void;
   keyMap: KeyMap;
-  leftHanded: boolean;
 }): JSX.Element => {
   const [bindingModalKeys, setBindingModalKeys]: [
     string,

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -35,7 +35,7 @@ const Bindings = (props: {
     NonEmptyArray<Readonly<NonEmptyArray<UIKeyDescriptor>>>
   > = [
     [
-      { key: "`", action: props.keyMap["`"] }, // this is on its own line so I don't need to fight with typescript for it to know that the array is NonEmptyArray
+      { key: "`", action: props.keyMap["`"], width: "3em" },
       ...Keys(["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]),
     ],
     [
@@ -44,12 +44,13 @@ const Bindings = (props: {
     ],
     [
       { type: "readonly", key: "esc", value: "Deselect", width: "6em" },
-      ...Keys(["a", "s", "d", "f", "g", "h", "j", "k", "l"]),
+      ...Keys(["a", "s", "d", "f", "g", "h", "j", "k", "l", ";"]),
     ],
     [
       { type: "modifier", key: "shift", value: "Snap", width: "7.5em" },
-      ...Keys(["z", "x", "c", "v", "b", "n", "m", "?"]),
-      { type: "modifier", key: "ctrl", width: "6em" },
+      ...Keys(["z", "x", "c", "v", "b", "n", "m", "/"]),
+      { type: "modifier", key: "ctrl", width: "3.5em" },
+      { type: "modifier", key: "alt", width: "3.5em" },
     ],
   ];
 

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -43,7 +43,7 @@ const Bindings = (props: {
       ...Keys(["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"]),
     ],
     [
-      { type: "readonly", key: "esc", value: "Deselect", width: "6em" },
+      { key: "esc", action: props.keyMap["esc"], width: "6em" },
       ...Keys(["a", "s", "d", "f", "g", "h", "j", "k", "l", ";"]),
     ],
     [

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -48,6 +48,7 @@ const Bindings = (props: {
         key,
         action: props.keyMap[key],
       })),
+      { type: "modifier", key: "ctrl", width: "6em" },
     ],
   ];
 

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -30,21 +30,21 @@ const Bindings = (props: {
   > = [
     [
       { type: "readonly", key: "tab", value: "Hide Toolbar", width: "4.5em" },
-      ...["q", "w", "e", "r", "t"].map((key) => ({
+      ...["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"].map((key) => ({
         key,
         action: props.keyMap[key],
       })),
     ],
     [
       { type: "readonly", key: "esc", value: "Deselect", width: "6em" },
-      ...["a", "s", "d", "f", "g"].map((key) => ({
+      ...["a", "s", "d", "f", "g", "h", "j", "k", "l"].map((key) => ({
         key,
         action: props.keyMap[key],
       })),
     ],
     [
       { type: "modifier", key: "shift", value: "Snap", width: "7.5em" },
-      ...["z", "x", "c", "v", "b"].map((key) => ({
+      ...["z", "x", "c", "v", "b", "n", "m", "?"].map((key) => ({
         key,
         action: props.keyMap[key],
       })),

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -29,6 +29,13 @@ const Bindings = (props: {
     NonEmptyArray<Readonly<NonEmptyArray<UIKeyDescriptor>>>
   > = [
     [
+      { key: "`", action: props.keyMap["`"] }, // this is on its own line so I don't need to fight with typescript for it to know that the array is NonEmptyArray
+      ...["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"].map((key) => ({
+        key,
+        action: props.keyMap[key],
+      })),
+    ],
+    [
       { type: "readonly", key: "tab", value: "Hide Toolbar", width: "4.5em" },
       ...["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"].map((key) => ({
         key,

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -4,7 +4,6 @@ import Modal from "react-modal";
 import { Action } from "../lib/action";
 import { KeyMap } from "../lib/keyboard";
 
-import { Key, UnbindableKey } from "./Keyboard";
 import BindingModal from "./BindingModal";
 import { Keyboard, UIKeyDescriptor } from "./Keyboard";
 import { NonEmptyArray } from "@mehra/ts";
@@ -26,21 +25,7 @@ const Bindings = (props: {
     null
   );
 
-  const rows = [
-    {
-      header: <UnbindableKey letter="tab" label="Hide Toolbar" width="4.5em" />,
-      letters: "qwert".split(""),
-    },
-    {
-      header: <UnbindableKey letter="esc" label="Deselect" width="6em" />,
-      letters: "asdfg".split(""),
-    },
-    {
-      header: <UnbindableKey letter="shift" label="Snap" width="7.5em" />,
-      letters: "zxcvb".split(""),
-    },
-  ];
-  const rows_new: Readonly<
+  const rows: Readonly<
     NonEmptyArray<Readonly<NonEmptyArray<UIKeyDescriptor>>>
   > = [
     [
@@ -83,7 +68,7 @@ const Bindings = (props: {
 
   return (
     <>
-      <Keyboard rows={rows_new} className={"bindings"} onclick={keyHandler} />
+      <Keyboard rows={rows} className={"bindings"} onclick={keyHandler} />
       <BindingModal
         letter={bindingModalKeys}
         action={bindingModalAction}

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Modal from "react-modal";
 
 import { Action, actionName } from "../lib/action";
-import { KeyMap, mirror } from "../lib/keyboard";
+import { KeyMap } from "../lib/keyboard";
 
 import Icon from "./Icon";
 import BindingModal from "./BindingModal";
@@ -16,19 +16,20 @@ Modal.setAppElement("#Overlay");
  *
  * Use if it is meaningful to indicate the app behavior of this key.
  */
-const UnbindableKey = (props: {
+const UnbindableKey = ({
+  label = "",
+  letter,
+  width,
+}: {
   letter: string;
   label?: string;
-  width: string;
-  leftHanded: boolean;
+  width?: string;
 }) => {
   return (
-    <div className="key" style={{ width: props.width }}>
-      <span className="letter">
-        {props.leftHanded ? mirror(props.letter) : props.letter}
-      </span>
+    <div className="key" style={{ width: width }}>
+      <span className="letter">{letter}</span>
       <div className="action">
-        <span className="unassigned">{props.label || ""}</span>
+        <span className="unassigned">{label}</span>
       </div>
     </div>
   );
@@ -38,7 +39,6 @@ const Key = (props: {
   letter: string;
   action?: Action;
   callback: (key: string) => void;
-  leftHanded: boolean;
 }) => {
   return (
     <button className="key" onClick={() => props.callback(props.letter)}>
@@ -48,9 +48,7 @@ const Key = (props: {
           {props.action === undefined ? "none" : actionName(props.action)}
         </span>
       </div>
-      <span className="letter">
-        {props.leftHanded ? mirror(props.letter) : props.letter}
-      </span>
+      <span className="letter">{props.letter}</span>
     </button>
   );
 };
@@ -72,36 +70,15 @@ const Bindings = (props: {
 
   const rows = [
     {
-      header: (
-        <UnbindableKey
-          letter="tab"
-          label="Hide Toolbar"
-          width="4.5em"
-          leftHanded={props.leftHanded}
-        />
-      ),
+      header: <UnbindableKey letter="tab" label="Hide Toolbar" width="4.5em" />,
       letters: "qwert".split(""),
     },
     {
-      header: (
-        <UnbindableKey
-          letter="esc"
-          label="Deselect"
-          width="6em"
-          leftHanded={props.leftHanded}
-        />
-      ),
+      header: <UnbindableKey letter="esc" label="Deselect" width="6em" />,
       letters: "asdfg".split(""),
     },
     {
-      header: (
-        <UnbindableKey
-          letter="shift"
-          label="Snap"
-          width="7.5em"
-          leftHanded={props.leftHanded}
-        />
-      ),
+      header: <UnbindableKey letter="shift" label="Snap" width="7.5em" />,
       letters: "zxcvb".split(""),
     },
   ];
@@ -126,7 +103,6 @@ const Bindings = (props: {
                 letter={letter}
                 action={props.keyMap[getModified(letter)]}
                 callback={keyHandler}
-                leftHanded={props.leftHanded}
               />
             ))}
             {props.leftHanded && header}

--- a/src/components/Bindings.tsx
+++ b/src/components/Bindings.tsx
@@ -1,62 +1,13 @@
 import React, { useState } from "react";
 import Modal from "react-modal";
 
-import { Action, actionName } from "../lib/action";
+import { Action } from "../lib/action";
 import { KeyMap } from "../lib/keyboard";
 
-import Icon from "./Icon";
+import { Key, UnbindableKey } from "./Keyboard";
 import BindingModal from "./BindingModal";
 
 Modal.setAppElement("#Overlay");
-
-/**
- * For keys whose bounding behavior cannot be changed;
- * these keys are already mapped to certain app events,
- * so the key diagram in the UI should not be a button.
- *
- * Use if it is meaningful to indicate the app behavior of this key.
- */
-const UnbindableKey = ({
-  label = "",
-  letter,
-  width,
-}: {
-  letter: string;
-  label?: string;
-  width?: string;
-}) => {
-  return (
-    <div className="key" style={{ width: width }}>
-      <span className="letter">{letter}</span>
-      <div className="action">
-        <span className="unassigned">{label}</span>
-      </div>
-    </div>
-  );
-};
-
-const Key = (props: {
-  letter: string;
-  action?: Action;
-  onclick: (key: string, event: React.MouseEvent<HTMLButtonElement>) => void;
-  width?: string;
-}) => {
-  return (
-    <button
-      className="key"
-      onClick={(event) => props.onclick(props.letter, event)}
-      style={{ width: props.width }}
-    >
-      <div className="action">
-        {props.action && Icon[props.action]}
-        <span className={props.action === undefined ? "unassigned" : undefined}>
-          {props.action === undefined ? "none" : actionName(props.action)}
-        </span>
-      </div>
-      <span className="letter">{props.letter}</span>
-    </button>
-  );
-};
 
 const Bindings = (props: {
   bind: (key: string, action: Action) => void;

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -61,7 +61,6 @@ const HelpModal = (props: {
         bind={props.bind}
         unbind={props.unbind}
         keyMap={props.keyMap}
-        modifier={keyModifier}
         leftHanded={leftHanded}
       />
       <p>

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -57,29 +57,6 @@ const HelpModal = (props: {
       <p>
         Press <b>?</b> to show or hide this screen.
       </p>
-      <p>
-        <button
-          className={keyModifier === "" ? "active" : undefined}
-          onClick={() => setKeyModifier("")}
-        >
-          unmodified
-        </button>
-        <button
-          className={keyModifier === "shift" ? "active" : undefined}
-          onClick={() => setKeyModifier("shift")}
-        >
-          with shift
-        </button>
-        <button
-          className={keyModifier === "ctrl" ? "active" : undefined}
-          onClick={() => setKeyModifier("ctrl")}
-        >
-          with ctrl
-        </button>
-        <button onClick={() => toggleHand()}>
-          {leftHanded ? "show left side" : "show right side"}
-        </button>
-      </p>
       <Bindings
         bind={props.bind}
         unbind={props.unbind}

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -20,24 +20,6 @@ const HelpModal = (props: {
   // toggleMobility: () => void;
 }): JSX.Element => {
   const [keyModifier, setKeyModifier] = useState("");
-  const [leftHanded, setLeftHanded] = useState(false);
-
-  const toggleHand = (): void => {
-    setLeftHanded((wasLeftHanded: boolean) => {
-      window.localStorage.setItem(
-        "leftHanded",
-        wasLeftHanded ? "false" : "true"
-      );
-
-      return !wasLeftHanded;
-    });
-  };
-
-  useEffect(() => {
-    if (window.localStorage.getItem("leftHanded") === "true") {
-      setLeftHanded(true);
-    }
-  }, []);
 
   return (
     <Modal
@@ -57,12 +39,7 @@ const HelpModal = (props: {
       <p>
         Press <b>?</b> to show or hide this screen.
       </p>
-      <Bindings
-        bind={props.bind}
-        unbind={props.unbind}
-        keyMap={props.keyMap}
-        leftHanded={leftHanded}
-      />
+      <Bindings bind={props.bind} unbind={props.unbind} keyMap={props.keyMap} />
       <p>
         Click a key to change the binding.{" "}
         <button onClick={() => props.reset()}>reset to default</button>

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Modal from "react-modal";
 
 import { Action } from "../lib/action";
@@ -28,20 +28,28 @@ const HelpModal = (props: {
       {Icon.close}
     </button>
     <p>
-      <span style={{ fontSize: "1.5em", fontWeight: "bold" }}>qboard</span>{" "}
-      <span style={{ color: "#666", marginLeft: "0.2em" }}>
+      <span style={{ fontSize: "1.5em", fontWeight: "bold" }}>qboard</span>
+      <span style={{ color: "#666", marginLeft: "0.5em" }}>
         The efficient digital whiteboard.
       </span>
-    </p>
-    <p>
-      Press <b>?</b> to show or hide this screen.
+      <span style={{ color: "#000", marginLeft: "0.5em" }}>
+        Press <b>?</b> to show or hide this screen.
+      </span>
     </p>
     <Bindings bind={props.bind} unbind={props.unbind} keyMap={props.keyMap} />
     <p>
       Click a key to change the binding.{" "}
       <button onClick={() => props.reset()}>reset to default</button>
     </p>
-    <p style={{ color: "#666" }}>
+    <p
+      style={{
+        bottom: "0",
+        color: "#666",
+        position: "absolute",
+        right: "0",
+        textAlign: "right",
+      }}
+    >
       By <a href="https://cjquines.com/">CJ Quines</a> and{" "}
       <a href="https://pihart.github.io/">Avi Mehra</a>. View on{" "}
       <a href="https://github.com/cjquines/qboard">Github</a>.

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -18,43 +18,39 @@ const HelpModal = (props: {
   toggleOpen: () => void;
   isMobile: boolean;
   // toggleMobility: () => void;
-}): JSX.Element => {
-  const [keyModifier, setKeyModifier] = useState("");
-
-  return (
-    <Modal
-      className="modal"
-      overlayClassName="modal-overlay help-modal"
-      isOpen={props.isOpen}
-    >
-      <button className="close" onClick={() => props.toggleOpen()}>
-        {Icon.close}
-      </button>
-      <p>
-        <span style={{ fontSize: "1.5em", fontWeight: "bold" }}>qboard</span>{" "}
-        <span style={{ color: "#666", marginLeft: "0.2em" }}>
-          The efficient digital whiteboard.
-        </span>
-      </p>
-      <p>
-        Press <b>?</b> to show or hide this screen.
-      </p>
-      <Bindings bind={props.bind} unbind={props.unbind} keyMap={props.keyMap} />
-      <p>
-        Click a key to change the binding.{" "}
-        <button onClick={() => props.reset()}>reset to default</button>
-      </p>
-      <p style={{ color: "#666" }}>
-        By <a href="https://cjquines.com/">CJ Quines</a> and{" "}
-        <a href="https://pihart.github.io/">Avi Mehra</a>. View on{" "}
-        <a href="https://github.com/cjquines/qboard">Github</a>.
-        {/* Use{" "}
+}): JSX.Element => (
+  <Modal
+    className="modal"
+    overlayClassName="modal-overlay help-modal"
+    isOpen={props.isOpen}
+  >
+    <button className="close" onClick={() => props.toggleOpen()}>
+      {Icon.close}
+    </button>
+    <p>
+      <span style={{ fontSize: "1.5em", fontWeight: "bold" }}>qboard</span>{" "}
+      <span style={{ color: "#666", marginLeft: "0.2em" }}>
+        The efficient digital whiteboard.
+      </span>
+    </p>
+    <p>
+      Press <b>?</b> to show or hide this screen.
+    </p>
+    <Bindings bind={props.bind} unbind={props.unbind} keyMap={props.keyMap} />
+    <p>
+      Click a key to change the binding.{" "}
+      <button onClick={() => props.reset()}>reset to default</button>
+    </p>
+    <p style={{ color: "#666" }}>
+      By <a href="https://cjquines.com/">CJ Quines</a> and{" "}
+      <a href="https://pihart.github.io/">Avi Mehra</a>. View on{" "}
+      <a href="https://github.com/cjquines/qboard">Github</a>.
+      {/* Use{" "}
         <a onClick={() => props.toggleMobility()} tabIndex={0}>
           {props.isMobile ? "desktop" : "mobile"} site
         </a>.*/}
-      </p>
-    </Modal>
-  );
-};
+    </p>
+  </Modal>
+);
 
 export default HelpModal;

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -37,27 +37,25 @@ const HelpModal = (props: {
       </span>
     </p>
     <Bindings bind={props.bind} unbind={props.unbind} keyMap={props.keyMap} />
-    <p>
-      Click a key to change the binding.{" "}
-      <button onClick={() => props.reset()}>reset to default</button>
-    </p>
-    <p
-      style={{
-        bottom: "0",
-        color: "#666",
-        position: "absolute",
-        right: "0",
-        textAlign: "right",
-      }}
-    >
-      By <a href="https://cjquines.com/">CJ Quines</a> and{" "}
-      <a href="https://pihart.github.io/">Avi Mehra</a>. View on{" "}
-      <a href="https://github.com/cjquines/qboard">Github</a>.
-      {/* Use{" "}
+    <div style={{ display: "flex", justifyContent: "space-between" }}>
+      <p>
+        Click a key to change the binding.{" "}
+        <button onClick={() => props.reset()}>reset to default</button>
+      </p>
+      <p
+        style={{
+          color: "#666",
+        }}
+      >
+        By <a href="https://cjquines.com/">CJ Quines</a> and{" "}
+        <a href="https://pihart.github.io/">Avi Mehra</a>. View on{" "}
+        <a href="https://github.com/cjquines/qboard">Github</a>.
+        {/* Use{" "}
         <a onClick={() => props.toggleMobility()} tabIndex={0}>
           {props.isMobile ? "desktop" : "mobile"} site
         </a>.*/}
-    </p>
+      </p>
+    </div>
   </Modal>
 );
 

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -90,3 +90,11 @@ interface ActionKeyDescriptor {
   readonly type?: "action";
   readonly action?: Action;
 }
+
+export type UIKeyDescriptor = {
+  /** The symbol or word to be shown as the label for the key */
+  readonly key: string;
+  /** The hard-coded width of the key. Currently only care about `em` units. */
+  readonly width?: `${number}${"em"}`;
+} & (ReadonlyKeyDescriptor | ModifierKeyDescriptor | ActionKeyDescriptor);
+

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -41,7 +41,7 @@ const ModifierKey = (props: {
   const [held, setHeld] = useState<boolean>(false);
   return (
     <button
-      className={`key modifier ${held ? "active" : ""}`}
+      className={`key modifier ${held ? "held" : ""}`}
       onClick={() => {
         if (held) props.set.delete(props.letter);
         else props.set.add(props.letter);

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -75,3 +75,18 @@ export const Key = (props: {
     </button>
   );
 };
+
+interface ReadonlyKeyDescriptor {
+  readonly type: "readonly";
+  readonly value?: string;
+}
+
+interface ModifierKeyDescriptor {
+  readonly type: "modifier";
+  readonly value?: string;
+}
+
+interface ActionKeyDescriptor {
+  readonly type?: "action";
+  readonly action?: Action;
+}

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { NonEmptyArray } from "@mehra/ts";
 import { Action, actionName } from "../lib/action";
 import Icon from "./Icon";
 
@@ -98,3 +99,62 @@ export type UIKeyDescriptor = {
   readonly width?: `${number}${"em"}`;
 } & (ReadonlyKeyDescriptor | ModifierKeyDescriptor | ActionKeyDescriptor);
 
+/**
+ * A keyboard UI component
+ */
+export const Keyboard = ({
+  rows,
+  onclick,
+  ...attrs
+}: {
+  /** A double array of keys, specifying the layout and behavior */
+  rows: Readonly<NonEmptyArray<Readonly<NonEmptyArray<UIKeyDescriptor>>>>;
+  /**
+   * Fired when a key button is pressed
+   *
+   * Technically, we shouldn't require this if every key is readonly.
+   * I don't care.
+   */
+  onclick: (a: {
+    key: string;
+    modifiers: Set<string>;
+    event: React.MouseEvent<HTMLButtonElement>;
+  }) => void;
+} & React.HTMLAttributes<HTMLDivElement>): JSX.Element => {
+  const modifiers = new Set<string>();
+
+  return (
+    <div {...attrs}>
+      {rows.map((row, index) => (
+        <div className={"row"} key={index}>
+          {row.map((keyData) =>
+            keyData.type === "readonly" ? (
+              <UnbindableKey
+                key={keyData.key}
+                letter={keyData.key}
+                label={keyData.value}
+                width={keyData.width}
+              />
+            ) : keyData.type === "modifier" ? (
+              <ModifierKey
+                key={keyData.key}
+                letter={keyData.key}
+                label={keyData.value}
+                set={modifiers}
+                width={keyData.width}
+              />
+            ) : (
+              <Key
+                key={keyData.key}
+                letter={keyData.key}
+                action={keyData.action}
+                width={keyData.width}
+                onclick={(key, event) => onclick({ key, modifiers, event })}
+              />
+            )
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -10,7 +10,7 @@ import Icon from "./Icon";
  *
  * Use if it is meaningful to indicate the app behavior of this key.
  */
-export const UnbindableKey = ({
+const UnbindableKey = ({
   label = "",
   letter,
   width,

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -28,6 +28,31 @@ export const UnbindableKey = ({
   );
 };
 
+const ModifierKey = (props: {
+  letter: string;
+  set: Set<string>;
+  label?: string;
+  width?: string;
+}) => {
+  const [held, setHeld] = useState<boolean>(false);
+  return (
+    <button
+      className={`key modifier ${held ? "active" : ""}`}
+      onClick={() => {
+        if (held) props.set.delete(props.letter);
+        else props.set.add(props.letter);
+        setHeld(!held);
+      }}
+      style={{ width: props.width }}
+    >
+      <div className="action">
+        <span className="unassigned">{props.label}</span>
+      </div>
+      <span className="letter">{props.letter}</span>
+    </button>
+  );
+};
+
 export const Key = (props: {
   letter: string;
   action?: Action;

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -54,7 +54,7 @@ const ModifierKey = (props: {
   );
 };
 
-export const Key = (props: {
+const Key = (props: {
   letter: string;
   action?: Action;
   onclick: (key: string, event: React.MouseEvent<HTMLButtonElement>) => void;

--- a/src/components/Keyboard.tsx
+++ b/src/components/Keyboard.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+import { Action, actionName } from "../lib/action";
+import Icon from "./Icon";
+
+/**
+ * For keys whose bounding behavior cannot be changed;
+ * these keys are already mapped to certain app events,
+ * so the key diagram in the UI should not be a button.
+ *
+ * Use if it is meaningful to indicate the app behavior of this key.
+ */
+export const UnbindableKey = ({
+  label = "",
+  letter,
+  width,
+}: {
+  letter: string;
+  label?: string;
+  width?: string;
+}) => {
+  return (
+    <div className="key" style={{ width: width }}>
+      <span className="letter">{letter}</span>
+      <div className="action">
+        <span className="unassigned">{label}</span>
+      </div>
+    </div>
+  );
+};
+
+export const Key = (props: {
+  letter: string;
+  action?: Action;
+  onclick: (key: string, event: React.MouseEvent<HTMLButtonElement>) => void;
+  width?: string;
+}) => {
+  return (
+    <button
+      className="key"
+      onClick={(event) => props.onclick(props.letter, event)}
+      style={{ width: props.width }}
+    >
+      <div className="action">
+        {props.action && Icon[props.action]}
+        <span className={props.action === undefined ? "unassigned" : undefined}>
+          {props.action === undefined ? "none" : actionName(props.action)}
+        </span>
+      </div>
+      <span className="letter">{props.letter}</span>
+    </button>
+  );
+};

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -1,4 +1,5 @@
 import { fabric } from "fabric";
+import { PartialRecord } from "@mehra/ts";
 
 import { Tool, Tools } from "./tools";
 import Pages from "./pages";
@@ -57,7 +58,7 @@ export enum Action {
   ExitFullScreen = "exitFullScreen",
 }
 
-const nameMap = {
+const nameMap: PartialRecord<Action, string> = {
   previousPage: "–Page",
   nextPage: "+Page",
   addPageStart: "-Page",
@@ -75,8 +76,8 @@ const nameMap = {
 };
 
 export const actionName = (action: Action): string => {
-  const name = nameMap[action] || action;
-  return name && name[0].toUpperCase() + name.slice(1);
+  const name = nameMap[action] ?? action;
+  return name[0].toUpperCase() + name.slice(1);
 };
 
 export default class ActionHandler {

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -1,4 +1,5 @@
 import { fabric } from "fabric";
+import React from "react";
 import { PartialRecord } from "@mehra/ts";
 
 import { Tool, Tools } from "./tools";
@@ -7,7 +8,6 @@ import FileHandler from "./files";
 import ClipboardHandler from "./clipboard";
 import HistoryHandler from "./history";
 import { Dash, Fill, Stroke, Style } from "./styles";
-import React from "react";
 
 export enum Action {
   PreviousPage = "previousPage",

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -68,7 +68,7 @@ const nameMap: PartialRecord<Action, string> = {
   addPageEnd: "+Page",
   selectAll: "Select All",
   duplicate: "Clone",
-  eraser: "Erase",
+  eraser: "Cut / Eraser",
   rectangle: "Rect.",
   latex: "LaTeX",
   transparent: "Unfilled",

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -65,7 +65,7 @@ const nameMap: PartialRecord<Action, string> = {
   addPageEnd: "+Page",
   selectAll: "Select All",
   duplicate: "Clone",
-  eraser: "Cut / Eraser",
+  eraser: "Erase",
   rectangle: "Rect.",
   transparent: "Unfilled",
   halfFilled: "Half Fill",

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -6,10 +6,6 @@ export type KeyMap = {
   [key: string]: Action;
 };
 
-export type MirrorMap = {
-  [key: string]: string;
-};
-
 export const defaultKeys: KeyMap = {
   q: Action.Laser,
   w: Action.Copy,
@@ -50,31 +46,6 @@ export const defaultKeys: KeyMap = {
   "0": Action.Help,
   "/": Action.Help,
   "shift + /": Action.Help,
-};
-
-const mirrorMap: MirrorMap = {
-  tab: "[",
-  q: "p",
-  w: "o",
-  e: "i",
-  r: "u",
-  t: "y",
-  esc: "'",
-  a: ";",
-  s: "l",
-  d: "k",
-  f: "j",
-  g: "h",
-  shift: "shift",
-  z: "/",
-  x: ".",
-  c: ",",
-  v: "m",
-  b: "n",
-};
-
-export const mirror = (key: string): string => {
-  return mirrorMap[key] || key.slice(0, -1) + mirrorMap[key.slice(-1)];
 };
 
 export default class KeyboardHandler {
@@ -128,7 +99,6 @@ export default class KeyboardHandler {
   unbind = (key: string): void => {
     delete this.keyMap[key];
     keyboardJS.unbind(key);
-    keyboardJS.unbind(mirror(key));
     this.updateState();
     this.save();
   };
@@ -136,7 +106,6 @@ export default class KeyboardHandler {
   bind = (key: string, action: Action): void => {
     this.keyMap[key] = action;
     keyboardJS.bind(key, () => this.doAction(this.keyMap[key]));
-    keyboardJS.bind(mirror(key), () => this.doAction(this.keyMap[key]));
     this.updateState();
     this.save();
   };
@@ -144,7 +113,6 @@ export default class KeyboardHandler {
   reset = (): void => {
     for (const key of Object.keys(this.keyMap)) {
       keyboardJS.unbind(key);
-      keyboardJS.unbind(mirror(key));
     }
     this.keyMap = { ...defaultKeys };
     this.bindAll();

--- a/src/styles/_bindings.scss
+++ b/src/styles/_bindings.scss
@@ -47,7 +47,7 @@
   }
 
   .key {
-    background: transparent;
+    background-color: transparent;
     border: 2px solid #bbb;
     border-radius: 0.3em;
     box-sizing: content-box;
@@ -56,6 +56,10 @@
     padding: 0;
     position: relative;
     width: 4em;
+
+    &.held {
+      background-color: #aaa8;
+    }
 
     .letter {
       color: #555;

--- a/src/styles/_bindings.scss
+++ b/src/styles/_bindings.scss
@@ -48,21 +48,21 @@
 
   .key {
     background-color: transparent;
-    border: 2px solid #bbb;
+    border: 2px solid #ccc;
     border-radius: 0.3em;
     box-sizing: content-box;
-    height: 4em;
+    height: 4.25rem;
     margin: 0.25em;
     padding: 0;
     position: relative;
-    width: 4em;
+    width: 4.25rem;
 
     &.held {
       background-color: #aaa8;
     }
 
     .letter {
-      color: #555;
+      color: #777;
       font-size: 0.9em;
       left: 0.25em;
       position: absolute;
@@ -71,13 +71,13 @@
     }
 
     .action {
-      bottom: 0.25em;
+      bottom: 0.1rem;
+      color: #444;
       font-size: 0.9em;
-      font-weight: bold;
       position: absolute;
-      right: 0.3em;
+      right: 0.3rem;
       text-align: right;
-      width: 3.9em;
+      width: 4rem;
     }
 
     i {
@@ -108,7 +108,7 @@
     }
 
     .unassigned {
-      color: #555;
+      color: #777;
       font-weight: normal;
     }
   }

--- a/src/styles/_bindings.scss
+++ b/src/styles/_bindings.scss
@@ -51,11 +51,11 @@
     border: 2px solid #ccc;
     border-radius: 0.3em;
     box-sizing: content-box;
-    height: 4.25rem;
+    height: 4.5rem;
     margin: 0.25em;
     padding: 0;
     position: relative;
-    width: 4.25rem;
+    width: 4.5rem;
 
     &.held {
       background-color: #ddd8;

--- a/src/styles/_bindings.scss
+++ b/src/styles/_bindings.scss
@@ -58,7 +58,7 @@
     width: 4.25rem;
 
     &.held {
-      background-color: #aaa8;
+      background-color: #ddd8;
     }
 
     .letter {

--- a/src/styles/_modals.scss
+++ b/src/styles/_modals.scss
@@ -66,8 +66,8 @@
   top: calc(max(50%, var(--height) / 2) - var(--height) / 2 + 2em);
 
   &.help-modal {
-    --height: 29.5em;
-    --width: 38em;
+    --height: 31.5em;
+    --width: 58em;
 
     background: #f8f8f8;
   }

--- a/src/styles/_modals.scss
+++ b/src/styles/_modals.scss
@@ -66,8 +66,8 @@
   top: calc(max(50%, var(--height) / 2) - var(--height) / 2 + 2em);
 
   &.help-modal {
-    --height: 27em;
-    --width: 57em;
+    --height: 26em;
+    --width: 55.5em;
 
     background: #f8f8f8;
   }

--- a/src/styles/_modals.scss
+++ b/src/styles/_modals.scss
@@ -66,8 +66,8 @@
   top: calc(max(50%, var(--height) / 2) - var(--height) / 2 + 2em);
 
   &.help-modal {
-    --height: 26em;
-    --width: 55.2em;
+    --height: 26.5em;
+    --width: 57.2em;
 
     background: #f8f8f8;
   }

--- a/src/styles/_modals.scss
+++ b/src/styles/_modals.scss
@@ -67,7 +67,7 @@
 
   &.help-modal {
     --height: 26em;
-    --width: 55.5em;
+    --width: 55.2em;
 
     background: #f8f8f8;
   }

--- a/src/styles/_modals.scss
+++ b/src/styles/_modals.scss
@@ -66,8 +66,8 @@
   top: calc(max(50%, var(--height) / 2) - var(--height) / 2 + 2em);
 
   &.help-modal {
-    --height: 28.5em;
-    --width: 60em;
+    --height: 27em;
+    --width: 57em;
 
     background: #f8f8f8;
   }

--- a/src/styles/_modals.scss
+++ b/src/styles/_modals.scss
@@ -66,8 +66,8 @@
   top: calc(max(50%, var(--height) / 2) - var(--height) / 2 + 2em);
 
   &.help-modal {
-    --height: 31.5em;
-    --width: 58em;
+    --height: 28.5em;
+    --width: 60em;
 
     background: #f8f8f8;
   }


### PR DESCRIPTION
Resolves https://github.com/cjquines/qboard/issues/120

Does not resolve these points; the first should go in a separate issue:
> * Make the localStorage format backwards and forwards compatible
> * #114

I am not updating the styles for the buttons under the assumption that you'd want to do that. The important ones are `button.key.modifier:hover` and `button.key.modifier.active:hover`, but you might also wish to distinguish `button.key.modifier` from `button.key`.

Currently shows `?` for the `/` key, which is slightly inaccurate. May wish to change. Also, I cannot override the `?` behavior.

Commit 59adc93529e426644ad326ea33f611a474625ad0 is large and does a few very different things. I can break it up if desired

Potential improvement:
When the shift modifier is active, may wish to replace the symbols for "\`", `/`, and `1`...`0` in the UI