### PR TITLE
Add LaTeX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-modal": "^3.11.2",
-        "react-tooltip": "^4.2.10"
+        "react-tooltip": "^4.2.10",
+        "tex-to-svg": "^0.2.0"
       },
       "devDependencies": {
         "@types/fabric": "^3.6.8",
@@ -7524,6 +7525,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -11632,6 +11641,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mathjax-full": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.1.4.tgz",
+      "integrity": "sha512-80lZZci7vqQQV2wdLcnFUtI7z5Aru0RL03wPw8JM6kFPmX4CA/SYfnlQQ1WIIBU+0p0YoxJ6Z3gAUcVzvDArhw==",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^3.2.0"
+      }
+    },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -12184,6 +12203,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -17268,6 +17292,27 @@
         "specificity": "bin/specificity"
       }
     },
+    "node_modules/speech-rule-engine": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.3.1.tgz",
+      "integrity": "sha512-/VtUopeX/saZ0yRFh2oQToYEDVGqHz3wU8B4ZnR2Jighe5AK8a38H14UGip5lTbkANz1KvTuPmHauEr7iwxH+w==",
+      "dependencies": {
+        "commander": ">=7.0.0",
+        "wicked-good-xpath": "^1.3.0",
+        "xmldom-sre": "^0.1.31"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
+    "node_modules/speech-rule-engine/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -18853,6 +18898,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tex-to-svg": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tex-to-svg/-/tex-to-svg-0.2.0.tgz",
+      "integrity": "sha512-YkP5V4O3u+i2odO5ETEISjVTemfzrx+YeG/XHXRoq3sfL0p8q4zDdlP/h+mna/4tEu6EylJOKzJws3iOnzU/rA==",
+      "dependencies": {
+        "mathjax-full": "^3.1.0"
       }
     },
     "node_modules/text-table": {
@@ -20627,6 +20680,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w="
+    },
     "node_modules/wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -20789,6 +20847,14 @@
       "integrity": "sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==",
       "dependencies": {
         "sax": "^1.2.1"
+      }
+    },
+    "node_modules/xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
+      "engines": {
+        "node": ">=0.1"
       }
     },
     "node_modules/xmlhttprequest-ssl": {
@@ -27287,6 +27353,11 @@
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -30577,6 +30648,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "mathjax-full": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.1.4.tgz",
+      "integrity": "sha512-80lZZci7vqQQV2wdLcnFUtI7z5Aru0RL03wPw8JM6kFPmX4CA/SYfnlQQ1WIIBU+0p0YoxJ6Z3gAUcVzvDArhw==",
+      "requires": {
+        "esm": "^3.2.25",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^3.2.0"
+      }
+    },
     "mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -31031,6 +31112,11 @@
           }
         }
       }
+    },
+    "mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -35325,6 +35411,23 @@
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
       "dev": true
     },
+    "speech-rule-engine": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.3.1.tgz",
+      "integrity": "sha512-/VtUopeX/saZ0yRFh2oQToYEDVGqHz3wU8B4ZnR2Jighe5AK8a38H14UGip5lTbkANz1KvTuPmHauEr7iwxH+w==",
+      "requires": {
+        "commander": ">=7.0.0",
+        "wicked-good-xpath": "^1.3.0",
+        "xmldom-sre": "^0.1.31"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        }
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -36548,6 +36651,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      }
+    },
+    "tex-to-svg": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/tex-to-svg/-/tex-to-svg-0.2.0.tgz",
+      "integrity": "sha512-YkP5V4O3u+i2odO5ETEISjVTemfzrx+YeG/XHXRoq3sfL0p8q4zDdlP/h+mna/4tEu6EylJOKzJws3iOnzU/rA==",
+      "requires": {
+        "mathjax-full": "^3.1.0"
       }
     },
     "text-table": {
@@ -37993,6 +38104,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w="
+    },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -38128,6 +38244,11 @@
       "requires": {
         "sax": "^1.2.1"
       }
+    },
+    "xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
     },
     "xmlhttprequest-ssl": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-modal": "^3.11.2",
-    "react-tooltip": "^4.2.10"
+    "react-tooltip": "^4.2.10",
+    "tex-to-svg": "^0.2.0"
   },
   "devDependencies": {
     "@types/fabric": "^3.6.8",

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -24,6 +24,7 @@ const Icon = {
   line: fasIcon("minus", { transform: "rotate(-45deg)" }),
   ellipse: fasIcon("circle"),
   rectangle: fasIcon("square"),
+  latex: fasIcon("font"),
 
   file: fasIcon("file"),
   open: fasIcon("folder-open"),

--- a/src/components/Stylebar.tsx
+++ b/src/components/Stylebar.tsx
@@ -18,10 +18,14 @@ const Stylebar = (props: {
   const fileButton = <button className="inactive">{Icon.file}</button>;
   const fileActions = [Action.Open, Action.Save, Action.Export];
 
-  const otherActions = [Action.Copy, Action.Paste];
-  const mobileActions = props.isMobile ? [Action.FullScreen] : [Action.Help];
-
   const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const otherActions = [
+    Action.Copy,
+    Action.Paste,
+    Action.Help,
+    !isFullscreen ? Action.EnterFullScreen : Action.ExitFullScreen,
+  ];
 
   useEffect(() => {
     setIsFullscreen(Boolean(document.fullscreenElement));
@@ -38,22 +42,11 @@ const Stylebar = (props: {
         cName="file-actions"
         outerButton={fileButton}
       />
+      <StyleMenu currentStyle={props.currentStyle} doAction={props.doAction} />
       <ButtonRow
         actions={otherActions}
         cName="other-actions vertical"
         callback={props.doAction}
-      />
-      <StyleMenu currentStyle={props.currentStyle} doAction={props.doAction} />
-      <ButtonRow
-        actions={mobileActions.map((action) =>
-          action === Action.FullScreen
-            ? !isFullscreen
-              ? Action.EnterFullScreen
-              : Action.ExitFullScreen
-            : action
-        )}
-        callback={props.doAction}
-        cName="mobile-actions vertical"
       />
     </div>
   );

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -32,6 +32,11 @@ const Toolbar = (props: {
           key={action}
         />
       ))}
+      <OverlayButton
+        action={Action.LaTeX}
+        callback={props.doAction}
+        // className={}
+      />
     </div>
   );
 };

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -7,6 +7,8 @@ import ClipboardHandler from "./clipboard";
 import HistoryHandler from "./history";
 import { Dash, Fill, Stroke, Style } from "./styles";
 import React from "react";
+import TeXToSVG from "tex-to-svg";
+import Page from "./page";
 
 export enum Action {
   PreviousPage = "previousPage",
@@ -35,6 +37,7 @@ export enum Action {
   Line = "line",
   Ellipse = "ellipse",
   Rectangle = "rectangle",
+  LaTeX = "latex",
 
   Dotted = "dotted",
   Dashed = "dashed",
@@ -66,6 +69,7 @@ const nameMap = {
   duplicate: "Clone",
   eraser: "Cut / Eraser",
   rectangle: "Rect.",
+  latex: "LaTeX",
   transparent: "Unfilled",
   halfFilled: "Half Fill",
   resetStyles: "Reset Styles",
@@ -80,7 +84,7 @@ export const actionName = (action: Action): string => {
 };
 
 export default class ActionHandler {
-  canvas: fabric.Canvas;
+  canvas: Page;
   readonly actionMap: Record<Action, () => void>;
 
   constructor(
@@ -152,6 +156,7 @@ export default class ActionHandler {
       line: () => this.switchTool(tools.Line),
       ellipse: () => this.switchTool(tools.Ellipse),
       rectangle: () => this.switchTool(tools.Rectangle),
+      latex: this.requestTeX,
 
       dotted: () => this.setDash(Dash.Dotted),
       dashed: () => this.setDash(Dash.Dashed),
@@ -205,5 +210,21 @@ export default class ActionHandler {
     } else {
       this.setStyle(null, null, fill);
     }
+  };
+
+  requestTeX = async () => {
+    const text = prompt("Hi");
+    if (text === null) return;
+
+    const img = await this.canvas.addImage(
+      `data:image/svg+xml,${encodeURIComponent(TeXToSVG(`\\text{${text}}`))}`,
+      {},
+      { scaleX: 3, scaleY: 3 }
+    );
+    this.history.add([img]);
+
+    // apparently this does something?
+    await this.history.undo();
+    await this.history.redo();
   };
 }

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -212,8 +212,8 @@ export default class ActionHandler {
     }
   };
 
-  requestTeX = async () => {
-    const text = prompt("Hi");
+  requestTeX = async (): Promise<void> => {
+    const text = prompt("Enter LaTeX source");
     if (text === null) return;
 
     const img = await this.canvas.addImage(

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -234,12 +234,8 @@ export default class FileHandler {
     file: File,
     cursor?: Cursor
   ): Promise<fabric.Object> =>
-    new Promise<fabric.Object>((resolve) =>
-      AsyncReader.readAsDataURL(file).then((result) =>
-        fabric.Image.fromURL(result.toString(), (obj: fabric.Image) => {
-          resolve(this.pages.canvas.placeObject(obj, cursor)[0]);
-        })
-      )
+    AsyncReader.readAsDataURL(file).then((result) =>
+      this.pages.canvas.addImage(result.toString(), cursor)
     );
 
   private handleJSON = async (file: File): Promise<number> => {

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -91,12 +91,17 @@ export default class Page extends fabric.Canvas {
 
   addImage = async (
     imageURL: string,
-    cursor?: Cursor
+    cursor?: Partial<Cursor>,
+    options?: fabric.IImageOptions
   ): Promise<fabric.Object> =>
     new Promise<fabric.Object>((resolve) =>
-      fabric.Image.fromURL(imageURL, (obj) => {
-        resolve(this.placeObject(obj, cursor)[0]);
-      })
+      fabric.Image.fromURL(
+        imageURL,
+        (obj) => {
+          resolve(this.placeObject(obj, cursor)[0]);
+        },
+        options
+      )
     );
 
   placeObject = (

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -89,6 +89,16 @@ export default class Page extends fabric.Canvas {
       });
     });
 
+  addImage = async (
+    imageURL: string,
+    cursor?: Cursor
+  ): Promise<fabric.Object> =>
+    new Promise<fabric.Object>((resolve) =>
+      fabric.Image.fromURL(imageURL, (obj) => {
+        resolve(this.placeObject(obj, cursor)[0]);
+      })
+    );
+
   placeObject = (
     obj: any,
     {

--- a/src/lib/qboard.ts
+++ b/src/lib/qboard.ts
@@ -306,20 +306,4 @@ export default class QBoard {
     const { x, y } = this.baseCanvas.getPointer(iEvent.e);
     this.baseCanvas.cursor = { x, y };
   };
-
-  requestTex = async () => {
-    const text = prompt("Hi");
-    if (text === null) return;
-
-    const img = await this.canvas.addImage(
-      `data:image/svg+xml,${encodeURIComponent(TeXToSVG(`\\text{${text}}`))}`,
-      {},
-      { scaleX: 3, scaleY: 3 }
-    );
-    this.history.add([img]);
-
-    // apparently this does something?
-    await this.history.undo();
-    await this.history.redo();
-  };
 }

--- a/src/lib/qboard.ts
+++ b/src/lib/qboard.ts
@@ -312,7 +312,9 @@ export default class QBoard {
     if (text === null) return;
 
     const img = await this.canvas.addImage(
-      `data:image/svg+xml,${encodeURIComponent(TeXToSVG(`\\text{${text}}`))}`
+      `data:image/svg+xml,${encodeURIComponent(TeXToSVG(`\\text{${text}}`))}`,
+      {},
+      { scaleX: 3, scaleY: 3 }
     );
     this.history.add([img]);
 

--- a/src/lib/qboard.ts
+++ b/src/lib/qboard.ts
@@ -315,5 +315,9 @@ export default class QBoard {
       `data:image/svg+xml,${encodeURIComponent(TeXToSVG(`\\text{${text}}`))}`
     );
     this.history.execute({ add: [img] });
+
+    // apparently this does something?
+    await this.history.undo();
+    await this.history.redo();
   };
 }

--- a/src/lib/qboard.ts
+++ b/src/lib/qboard.ts
@@ -314,7 +314,7 @@ export default class QBoard {
     const img = await this.canvas.addImage(
       `data:image/svg+xml,${encodeURIComponent(TeXToSVG(`\\text{${text}}`))}`
     );
-    this.history.execute({ add: [img] });
+    this.history.add([img]);
 
     // apparently this does something?
     await this.history.undo();

--- a/src/lib/qboard.ts
+++ b/src/lib/qboard.ts
@@ -22,6 +22,7 @@ type Async<T = void> = T | Promise<T>;
 
 type FabricHandler<T extends fabric.IEvent = fabric.IEvent> = (e: T) => Async;
 import AssertType from "../types/assert";
+import TeXToSVG from "tex-to-svg";
 
 export interface QBoardState {
   dragActive: boolean;
@@ -304,5 +305,15 @@ export default class QBoard {
   updateCursor: FabricHandler = (iEvent) => {
     const { x, y } = this.baseCanvas.getPointer(iEvent.e);
     this.baseCanvas.cursor = { x, y };
+  };
+
+  requestTex = async () => {
+    const text = prompt("Hi");
+    if (text === null) return;
+
+    const img = await this.canvas.addImage(
+      `data:image/svg+xml,${encodeURIComponent(TeXToSVG(`\\text{${text}}`))}`
+    );
+    this.history.execute({ add: [img] });
   };
 }

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,4 +1,5 @@
 import { fabric } from "fabric";
+
 import Page from "./page";
 import ClipboardHandler from "./clipboard";
 import HistoryHandler from "./history";


### PR DESCRIPTION
Resolves #76
Closes #91 (this issue is open for the converse of its title; not needed after this PR)

The fundamental issue I was facing when doing this earlier is I don't know how to make inline editing play nicely, from a UI standpoint. It's not really a tool, but I was treating it as if it should've been.

Here, the function `qboard.requestTex()` (now `qboard.action.requestTeX()`)  prompts for source code, which gets converted to SVG by MathJax and then placed into the canvas as a direct image insertion. _No live TeX is added to the canvas._

Now, to edit the TeX source of any placed image, I imagine adding a modal where you enter the text, and once you click ok, the image updates. Possibly add a live preview using the HTML version of MathJax. In my view, this is out of scope for this immediate PR.

This works beautifully for me, no issues at all. It defaults to text mode and you can just use it as a basic LaTeX environment.

However, there is a bit of a hack, there is an undo-redo operation at the end of the logical function because that is somehow needed:
https://github.com/cjquines/qboard/blob/59a310d1f17d8675876d7902007646a3f37a0adc/src/lib/qboard.ts#L310-L324

---

In the current form, https://github.com/cjquines/qboard/issues/76#issuecomment-720896644 is not an issue, because we don't at all store the LaTeX source.