### PR TITLE
Don't render erroneous mathjax to canvas

### DIFF
--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -84,7 +84,17 @@ export const actionName = (action: Action): string => {
   return name[0].toUpperCase() + name.slice(1);
 };
 
-class LaTeXError extends MalformedExpressionException {}
+class LaTeXError extends MalformedExpressionException {
+  constructor(message: string, sourceTeX?: string) {
+    super(
+      sourceTeX === undefined
+        ? message
+        : `${message}
+
+in LaTeX ${sourceTeX}`
+    );
+  }
+}
 
 export default class ActionHandler {
   canvas: Page;
@@ -230,7 +240,14 @@ export default class ActionHandler {
     if (MathJaxErrorNode !== null) {
       const errorText = MathJaxErrorNode.getAttribute("title")!;
       // eslint-disable-next-line no-console
-      console.error(new LaTeXError(errorText), MathJaxErrorNode);
+      console.error(
+        new LaTeXError(
+          errorText,
+          MathJaxErrorNode.querySelector('[data-mml-node="mtext"] text')
+            ?.textContent ?? undefined
+        ),
+        MathJaxErrorNode
+      );
 
       window.alert(
         `Error in LaTeX: ${errorText}

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -1,6 +1,6 @@
 import { fabric } from "fabric";
 import React from "react";
-import { PartialRecord } from "@mehra/ts";
+import { MalformedExpressionException, PartialRecord } from "@mehra/ts";
 import TeXToSVG from "tex-to-svg";
 
 import { Tool, Tools } from "./tools";
@@ -83,6 +83,8 @@ export const actionName = (action: Action): string => {
   const name = nameMap[action] ?? action;
   return name[0].toUpperCase() + name.slice(1);
 };
+
+class LaTeXError extends MalformedExpressionException {}
 
 export default class ActionHandler {
   canvas: Page;
@@ -228,7 +230,7 @@ export default class ActionHandler {
     if (MathJaxErrorNode !== null) {
       const errorText = MathJaxErrorNode.getAttribute("title")!;
       // eslint-disable-next-line no-console
-      console.error(`LaTeX error: ${errorText}`, MathJaxErrorNode);
+      console.error(new LaTeXError(errorText), MathJaxErrorNode);
 
       window.alert(
         `Error in LaTeX: ${errorText}

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -93,8 +93,8 @@ export default class Page extends fabric.Canvas {
     imageURL: string,
     cursor?: Partial<Cursor>,
     options?: fabric.IImageOptions
-  ): Promise<fabric.Object> =>
-    new Promise<fabric.Object>((resolve) =>
+  ): Promise<fabric.Image> =>
+    new Promise<fabric.Image>((resolve) =>
       fabric.Image.fromURL(
         imageURL,
         (obj) => {

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -104,17 +104,17 @@ export default class Page extends fabric.Canvas {
       )
     );
 
-  placeObject = (
-    obj: FabricObject,
+  placeObject = <T extends FabricObject>(
+    obj: T,
     {
       x = this.canvasWidth / 2,
       y = this.canvasHeight / 2,
     }: Partial<Cursor> = this.cursor ?? {}
-  ): fabric.Object[] => {
+  ): T extends fabric.ICollection<unknown> ? fabric.Object[] : [T] => {
     this.discardActiveObject();
     const id = this.getNextId();
 
-    (obj as ObjectId).set({
+    ((obj as FabricObject) as ObjectId).set({
       id,
       left: x,
       top: y,
@@ -122,7 +122,7 @@ export default class Page extends fabric.Canvas {
       originY: "center",
     });
 
-    let returnObjects = [obj];
+    let returnObjects;
 
     if (isFabricCollection(obj)) {
       obj.canvas = this;
@@ -135,6 +135,8 @@ export default class Page extends fabric.Canvas {
       returnObjects = obj.getObjects();
     } else {
       this.add(obj);
+
+      returnObjects = [obj];
     }
     this.setActiveObject(obj);
     this.requestRenderAll();


### PR DESCRIPTION
Resolves #150 
There has to be some native way that hooks into mathjax but this works fine

1d39f69d6806633e6eaf6b5ded2367266b93d801 and 86cfa4c3d12c564ff01ead44356df07768ceb32d don't matter for this change so they can be moved out if desired