### PR TITLE
Clear localStorage keyMap on reset

### DIFF
--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -119,7 +119,8 @@ export default class KeyboardHandler {
 
   /**
    * Creates a keyboard.js binding from the key combination {@param key} to the action {@param action},
-   * writing to `localStorage` if {@param save}
+   * writing to `localStorage` if {@param save}.
+   * The binding reacts only to the `press` event and not the `release` event.
    */
   bind = (key: string, action: Action, save = true): void => {
     this.keyMap[key] = action;

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -85,6 +85,9 @@ export default class KeyboardHandler {
     }
   }
 
+  /**
+   * Writes the map to `localStorage`
+   */
   save = (): void => {
     window.localStorage.setItem("keyMap", JSON.stringify(this.keyMap));
   };
@@ -96,9 +99,13 @@ export default class KeyboardHandler {
     window.localStorage.removeItem("keyMap");
   };
 
-  bindAll = (): void => {
+  /**
+   * Wrapper to bind every binding defined in `this.keyMap`,
+   * writing to `localStorage` if {@param save}
+   */
+  bindAll = (save = false): void => {
     for (const [key, value] of Object.entries(this.keyMap)) {
-      this.bind(key, value);
+      this.bind(key, value, save);
     }
     this.updateState();
   };
@@ -110,11 +117,16 @@ export default class KeyboardHandler {
     this.save();
   };
 
-  bind = (key: string, action: Action): void => {
+  /**
+   * Creates a keyboard.js binding from the key combination {@param key} to the action {@param action},
+   * writing to `localStorage` if {@param save}
+   */
+  bind = (key: string, action: Action, save = true): void => {
     this.keyMap[key] = action;
     keyboardJS.bind(key, () => this.doAction(this.keyMap[key]));
     this.updateState();
-    this.save();
+
+    if (save) this.save();
   };
 
   reset = (): void => {

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -89,6 +89,13 @@ export default class KeyboardHandler {
     window.localStorage.setItem("keyMap", JSON.stringify(this.keyMap));
   };
 
+  /**
+   * Removes the map from `localStorage`
+   */
+  clear = (): void => {
+    window.localStorage.removeItem("keyMap");
+  };
+
   bindAll = (): void => {
     for (const [key, value] of Object.entries(this.keyMap)) {
       this.bind(key, value);
@@ -116,6 +123,6 @@ export default class KeyboardHandler {
     }
     this.keyMap = { ...defaultKeys };
     this.bindAll();
-    this.save();
+    this.clear();
   };
 }


### PR DESCRIPTION
Resolves #172 

I don't really like how `KeyboardHandler > bind()` also handles saving but I don't feel that it's within the scope of this PR to change that behavior