### PR TITLE
Revert "Don't use private _toObject method"

### DIFF
--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -60,7 +60,9 @@ export default class Page extends fabric.Canvas {
         new fabric.ActiveSelection(selection, { canvas: this })
       );
     }
-    return objects.map((obj) => obj.toObject(["strokeUniform"]));
+    return objects.map((obj) =>
+      (this as any)._toObject(obj, "toObject", ["strokeUniform"])
+    );
   };
 
   apply = (ids: number[], newObjects: fabric.Object[] | null): void => {

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -61,12 +61,14 @@ export default class Page extends fabric.Canvas {
       );
     }
     return objects.map((obj) =>
-      // This is needed for selection groups to be serialized properly
+      // This is needed for selection groups to be serialized properly.
       // If directly using `obj.toObject` it somehow depends on the selection remaining active,
-      // as claimed in https://github.com/fabricjs/fabric.js/blob/2eabc92a3221dd628576b1bb029a5dc1156bdc06/src/canvas.class.js#L1262-L1272
+      // as claimed in <https://github.com/fabricjs/fabric.js/blob/2eabc92a3221dd628576b1bb029a5dc1156bdc06/src/canvas.class.js#L1262-L1272>.
       //
-      // We tried using that method in b9cb04c3dacd951785ce4e94ce0c629c09319ec3 but this caused issue #171
-      // See https://github.com/cjquines/qboard/issues/171 for more details
+      // We tried using that method in b9cb04c3dacd951785ce4e94ce0c629c09319ec3 but this caused issue #171.
+      // See https://github.com/cjquines/qboard/issues/171
+      // and https://github.com/cjquines/qboard/issues/176
+      // for more details.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (this as any)._toObject(obj, "toObject", ["strokeUniform"])
     );

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -61,6 +61,13 @@ export default class Page extends fabric.Canvas {
       );
     }
     return objects.map((obj) =>
+      // This is needed for selection groups to be serialized properly
+      // If directly using `obj.toObject` it somehow depends on the selection remaining active,
+      // as claimed in https://github.com/fabricjs/fabric.js/blob/2eabc92a3221dd628576b1bb029a5dc1156bdc06/src/canvas.class.js#L1262-L1272
+      //
+      // We tried using that method in b9cb04c3dacd951785ce4e94ce0c629c09319ec3 but this caused issue #171
+      // See https://github.com/cjquines/qboard/issues/171 for more details
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (this as any)._toObject(obj, "toObject", ["strokeUniform"])
     );
   };


### PR DESCRIPTION
This reverts commit b9cb04c3dacd951785ce4e94ce0c629c09319ec3.

# Conflicts:
#	src/lib/page.ts

Resolves https://github.com/cjquines/qboard/issues/171