### PR TITLE
Highlight selected buttons

### DIFF
--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -36,10 +36,6 @@ button {
   &.disabled:hover {
     cursor: unset;
   }
-
-  &:focus {
-    outline: none;
-  }
 }
 
 .__react_component_tooltip {


### PR DESCRIPTION
Resolves https://github.com/cjquines/qboard/issues/190

- Remove `button:focus { outline: none }`
  
