### PR TITLE
A new system for assigning IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "qboard",
       "version": "0.1.1",
       "license": "MIT",
       "dependencies": {

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -93,7 +93,7 @@ const isValidQboardFile = (object: unknown): object is QboardFile => {
  * The current qboard file format
  */
 interface CurrentQboardFile {
-  "qboard-version": 1;
+  "qboard-version": 2;
   pages: PageJSON[];
 }
 
@@ -156,7 +156,7 @@ export class JSONWriter {
 
   constructor(pagesJSON: PageJSON[]) {
     this.sourceJSON = {
-      "qboard-version": 1,
+      "qboard-version": 2,
       pages: pagesJSON,
     };
   }

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -83,7 +83,7 @@ export default class HistoryHandler {
 
   private setIdIfNotPresent = (object: FabricObject): number => {
     AssertType<ObjectId>(object);
-    if (object.idVersion !== 1 || object.id == null) {
+    if (object.idVersion !== 1 || object.id === undefined) {
       // Legacy versions would export ids in the serialized files,
       // and we don't want those because they can clash.
       // Instead of deleting all these ids at import time,

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -62,7 +62,7 @@ export default class HistoryHandler {
   modify = (objects: fabric.Object[]): void =>
     this.save({ oldObjects: this.selection, newObjects: objects });
 
-  save = ({
+  private save = ({
     oldObjects,
     newObjects,
   }:

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -83,7 +83,15 @@ export default class HistoryHandler {
 
   private setIdIfNotPresent = (object: FabricObject): number => {
     AssertType<ObjectId>(object);
-    return (object.id = object.id ?? this.getNextId());
+    if (object.idVersion !== 1 || object.id == null) {
+      // Legacy versions would export ids in the serialized files,
+      // and we don't want those because they can clash.
+      // Instead of deleting all these ids at import time,
+      // we do it at history push time.
+      object.idVersion = 1;
+      object.id = this.getNextId();
+    }
+    return object.id;
   };
 
   /**

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -58,18 +58,23 @@ export default class Page extends fabric.Canvas {
         new fabric.ActiveSelection(selection, { canvas: this })
       );
     }
-    return objects.map((obj) =>
-      // This is needed for selection groups to be serialized properly.
-      // If directly using `obj.toObject` it somehow depends on the selection remaining active,
-      // as claimed in <https://github.com/fabricjs/fabric.js/blob/2eabc92a3221dd628576b1bb029a5dc1156bdc06/src/canvas.class.js#L1262-L1272>.
-      //
-      // We tried using that method in b9cb04c3dacd951785ce4e94ce0c629c09319ec3 but this caused issue #171.
-      // See https://github.com/cjquines/qboard/issues/171
-      // and https://github.com/cjquines/qboard/issues/176
-      // for more details.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this as any)._toObject(obj, "toObject", ["data", "strokeUniform"])
-    );
+    return objects
+      .map((obj) =>
+        // This is needed for selection groups to be serialized properly.
+        // If directly using `obj.toObject` it somehow depends on the selection remaining active,
+        // as claimed in <https://github.com/fabricjs/fabric.js/blob/2eabc92a3221dd628576b1bb029a5dc1156bdc06/src/canvas.class.js#L1262-L1272>.
+        //
+        // We tried using that method in b9cb04c3dacd951785ce4e94ce0c629c09319ec3 but this caused issue #171.
+        // See https://github.com/cjquines/qboard/issues/171
+        // and https://github.com/cjquines/qboard/issues/176
+        // for more details.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (this as any)._toObject(obj, "toObject", ["data", "strokeUniform"])
+      )
+      .map((obj) => {
+        delete obj.id;
+        return obj;
+      });
   };
 
   apply = (

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -45,7 +45,9 @@ export default class Page extends fabric.Canvas {
   getObjectByIds = (ids: readonly number[]): fabric.Object[] =>
     this.getObjects().filter((object) => {
       AssertType<ObjectId>(object);
-      return object.id != null && ids.includes(object.id);
+      return (
+        object.idVersion === 1 && object.id != null && ids.includes(object.id)
+      );
     });
 
   serialize = (objects: readonly fabric.Object[]): fabric.Object[] => {

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -80,9 +80,7 @@ export default class Page extends fabric.Canvas {
     newObjects: fabric.Object[] | null
   ): void => {
     const oldObjects = this.getObjectByIds(ids);
-    if (oldObjects.length) {
-      this.remove(...oldObjects);
-    }
+    this.remove(...oldObjects);
     if (newObjects?.length) {
       const addObjects = (objects) => {
         objects.forEach((object: ObjectId, i) => {

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -90,9 +90,8 @@ export default class Page extends fabric.Canvas {
         this.requestRenderAll();
       };
       fabric.util.enlivenObjects(newObjects, addObjects, "fabric");
-    } else {
-      this.requestRenderAll();
     }
+    this.requestRenderAll();
   };
 
   loadFromJSONAsync = async (json: unknown): Promise<void> =>

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -133,7 +133,7 @@ export default class Page extends fabric.Canvas {
     );
 
   /**
-   * Creates an id for {@param obj} or its subobjects and places it at ({@param x}, {@param y}).
+   * Places {@param obj} at ({@param x}, {@param y}).
    * Returns the array of subobjects, if obj is a collection, or else a singleton containing obj
    */
   placeObject = <T extends FabricObject>(

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -144,7 +144,7 @@ export default class Page extends fabric.Canvas {
     }: Partial<Cursor> = this.cursor ?? {}
   ): T extends fabric.ICollection<unknown> ? fabric.Object[] : [T] => {
     this.discardActiveObject();
-    (obj as FabricObject as ObjectId).set({
+    ((obj as FabricObject) as ObjectId).set({
       left: x,
       top: y,
       originX: "center",

--- a/src/lib/page.ts
+++ b/src/lib/page.ts
@@ -82,8 +82,8 @@ export default class Page extends fabric.Canvas {
     const oldObjects = this.getObjectByIds(ids);
     this.remove(...oldObjects);
     if (newObjects?.length) {
-      const addObjects = (objects) => {
-        objects.forEach((object: ObjectId, i) => {
+      const addObjects = (objects: ObjectId[]) => {
+        objects.forEach((object, i) => {
           object.id = ids[i];
         });
         this.add(...objects);

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -41,7 +41,6 @@ export default class Pages {
 
   savePage = (): void => {
     this.pagesJSON[this.currentIndex] = this.canvas.toObject([
-      "id",
       "data",
       "strokeUniform",
     ]);

--- a/src/lib/qboard.ts
+++ b/src/lib/qboard.ts
@@ -15,7 +15,6 @@ import {
   FabricIEvent,
   GuaranteedIObjectOptions,
   isFabricCollection,
-  ObjectId,
   PathEvent,
 } from "../types/fabric";
 

--- a/src/lib/qboard.ts
+++ b/src/lib/qboard.ts
@@ -242,7 +242,6 @@ export default class QBoard {
     const { x, y } = this.canvas.getPointer(e.e);
     this.isDown = true;
     this.currentObject = await this.activeTool.draw(x, y, this.drawerOptions);
-    (this.currentObject as ObjectId).id = this.baseCanvas.getNextId();
     this.canvas.add(this.currentObject);
     this.canvas.requestRenderAll();
   };
@@ -299,8 +298,8 @@ export default class QBoard {
     const objects = isFabricCollection(e.target)
       ? e.target.getObjects()
       : [e.target];
-    this.history.modify(objects);
-    this.history.store(objects);
+    this.history.modify(objects); // old selection was replaced with this selection
+    this.history.store(objects); // new state of selection
   };
 
   updateCursor: FabricHandler = (iEvent) => {

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -147,7 +147,6 @@ export class Move extends RequiresBase {}
 
 export class Pen extends Brush {
   pathCreated = (e: PathEvent): void => {
-    e.path.id = this.baseCanvas.getNextId();
     this.history.add([e.path]);
   };
   setBrush = (

--- a/src/types/fabric.ts
+++ b/src/types/fabric.ts
@@ -15,6 +15,7 @@ export interface FabricObject extends fabric.Object {
 
 export interface ObjectId extends FabricObject {
   id?: number;
+  idVersion?: 1;
 }
 
 export type FabricIEvent = fabric.IEvent & {

--- a/src/types/fabric.ts
+++ b/src/types/fabric.ts
@@ -14,7 +14,7 @@ export interface FabricObject extends fabric.Object {
 }
 
 export interface ObjectId extends FabricObject {
-  id: number;
+  id?: number;
 }
 
 export type FabricIEvent = fabric.IEvent & {


### PR DESCRIPTION
* Add IDs to objects only when necessary (when adding to history)
* Don't serialize IDs to file
* Handle legacy files (where IDs are already serialized) by ignoring their IDs because they don't have the `idVersion` field
   * Don't try to strip everything at file import time


* Resolves https://github.com/cjquines/qboard/issues/211
* Resolves https://github.com/cjquines/qboard/issues/95